### PR TITLE
fix(dashboard): pin coverage donut svg to a fixed px size

### DIFF
--- a/memory-bank/agentLog.md
+++ b/memory-bank/agentLog.md
@@ -561,3 +561,24 @@ All three queued items landed; green (svelte-check 0). Built live with Michael's
 - Files: NEW CatalogByDivision.svelte; AgencyDashboard.svelte (swap + drop dead cats/maxCat/resolveCategoryIcon
   import + `.bars.scroll`/`.bar-ic` CSS); AgentsWorkspace.svelte; PersonaBody.svelte; corpus.svelte.ts (iconOf);
   categoryIcon.ts. Next: merge PR #3 → main, then VM matrix Win/Linux build verify.
+
+## 2026-06-15 (later 5) — PR #3 MERGED to main; giant-donut fix; full VM matrix GREEN (21/0/1)
+- **PR #3 merged** (`release-planning → main`, merge commit 633ff3ff). Catalog-by-division + icon work shipped.
+- **Giant CoverageDonut bug** (Michael: "that ain't right" — one donut ballooned to full card width). ROOT
+  CAUSE: the donut `<svg>` had only `viewBox` + relied on `.cd-chart { width:132px }`; when that scoped style
+  doesn't apply (stale/raced webview CSS, e.g. a dead `tauri dev`'s last frame), a viewBox-only svg grows to
+  full width and its 1:1 ratio balloons into one giant circle. Verified source + dev-served CSS were BOTH
+  correct → it was a stale webview. FIX (hardened, not just a reload): pinned the svg with explicit
+  `width="132" height="132"` attributes + `.cd-chart svg { width:132px;height:132px }` (was 100%) so it has a
+  hard px floor and can never balloon again. `CoverageDonuts.svelte`, svelte-check 0. (HealthDonut shares the
+  technique but renders fine; left as-is per minimal-change.)
+- **⚠️ FOOTGUN (bit us again): `tauri dev`/`tauri build` on macOS auto-rewrites `src-tauri/Cargo.toml`** — it
+  ADDS `macos-private-api` to the BASE `[dependencies] tauri` to match the config (it doesn't understand our
+  base-excludes / `[target.macos]`-includes split). That breaks `validate-config.mjs` ("base excludes
+  macos-private-api") AND the macOS-release + Linux cargo gates ("tauri features don't match the allowlist").
+  The 2nd matrix run failed 3 steps purely because I'd launched `tauri dev` to show the donut. RULE: before any
+  cross-platform gate, **stop `tauri dev` and `git checkout -- src-tauri/Cargo.toml`** (revert the base-feature
+  injection; line ~17 must NOT list macos-private-api, only line ~89 `[target.macos]` does). See [[tauri-dev-rewrites-cargo-toml-base-features]].
+- **Final matrix run 20260615T190208Z: 21 passed / 0 failed / 1 skip** (skip = opt-in PHASE_C_STRICT_TAURI).
+  arm64 PASS after Michael closed the running .exe that held the file lock on `C:\AgencyAgentsWinTarget`.
+- **Uncommitted**: CoverageDonuts.svelte (the donut hardening) — awaiting Michael's go to branch + PR (on main).

--- a/src/lib/components/CoverageDonuts.svelte
+++ b/src/lib/components/CoverageDonuts.svelte
@@ -92,7 +92,7 @@
         {@const hot = hovered ? countIn(d.tool, hovered) : 0}
         <div class="cd-cell">
           <div class="cd-chart">
-            <svg viewBox="0 0 120 120" role="img" aria-label={`${d.label}: ${d.total} agents across ${d.segs.length} divisions`}>
+            <svg width="132" height="132" viewBox="0 0 120 120" role="img" aria-label={`${d.label}: ${d.total} agents across ${d.segs.length} divisions`}>
               <g transform="rotate(-90 60 60)">
                 <circle cx="60" cy="60" r={R} fill="none" style="stroke: var(--color-surface-sunken)" stroke-width={STROKE} />
                 {#each arcs as a (a.slug)}
@@ -163,7 +163,12 @@
   /* flex: none — like HealthDonut's .hd-chart — so the flex row never resizes the
      donut; every donut stays a fixed 132×132 regardless of label length. */
   .cd-chart { position: relative; width: 132px; height: 132px; flex: none; }
-  .cd-chart svg { width: 100%; height: 100%; display: block; }
+  /* Pin the svg to a fixed px size (not 100%) so the donut can never expand to
+     the card width if .cd-chart's scoped style fails to apply / races on load —
+     a viewBox-only svg otherwise grows to full width and its 1:1 ratio balloons
+     it into one giant circle. The width/height attributes are the last-resort
+     floor; this rule keeps it crisp when the styles are present. */
+  .cd-chart svg { width: 132px; height: 132px; display: block; }
 
   .seg { cursor: pointer; transition: opacity var(--motion-duration-fast) var(--motion-ease-out); }
   .seg.dim { opacity: 0.18; }


### PR DESCRIPTION
## What

The per-tool coverage donuts could balloon into one giant full-width circle (see below). Fixes that with a hard pixel floor on the donut `<svg>`.

## Root cause

The donut `<svg>` carried only a `viewBox` and relied entirely on `.cd-chart { width: 132px }` to constrain its size. When that scoped style doesn't apply — a raced or stale webview CSS injection (e.g. a dead `tauri dev`'s last rendered frame) — a viewBox-only svg grows to the full card width, and its 1:1 aspect ratio balloons it into one giant circle.

Confirmed both the source CSS and the dev-server-served CSS were correct, so this was a render-time staleness, not a missing rule.

## Fix

- Add explicit `width="132" height="132"` attributes to the `<svg>` (a last-resort floor that survives even with zero scoped CSS).
- Pin `.cd-chart svg { width: 132px; height: 132px }` (was `100%`) so it's crisp when styles are present.

Net effect: the donut can never expand to its container again, regardless of whether the wrapper's scoped style loaded.

## Validation

- `svelte-check`: 0 errors
- Full Phase C cross-platform matrix (macOS + Ubuntu deb/rpm/appimage + Windows arm64/x64): **21 passed / 0 failed / 1 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)