### PR TITLE
fix(ui): apply the saved default-landing section at launch

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,8 +1,11 @@
 # Active Context — Agency Agents
 
-**State**: BUILD (pre-release polish, on `release-planning`). Phase C merged to `main`. **Release plan
-LOCKED & documented, NOT cut yet** — v0.1.0, signed/notarized manual DMG, `SKIP_UPDATER=1`, auto-update
-deferred. Runbook: `docs/BUILD.md#Release Checklist`; decision in `decisions.md` (2026-06-14).
+**State**: BUILD (pre-release polish). Release-planning + 3 PRs (catalog-by-division+icons #3, donut-size #4,
+read-catalog-divisions.json #5) all MERGED to `main`. Catalog `divisions.json` is now canonical (#592) with
+`integrations` purged from the source scan (#593). **Release plan LOCKED & documented, NOT cut yet** — v0.1.0,
+signed/notarized manual DMG, `SKIP_UPDATER=1`, auto-update deferred. Runbook: `docs/BUILD.md#Release Checklist`;
+decision in `decisions.md` (2026-06-14). **Near release-ready** — see `agentLog.md` 2026-06-15 (later 7) for the
+two remaining hygiene items (bundled `agency-categories.json` ↔ `divisions.json` sync; reconsider `strategy`).
 **Last updated**: 2026-06-15
 
 ## ✅ Pre-release polish (2026-06-15) — committed + pushed on `release-planning`

--- a/memory-bank/agentLog.md
+++ b/memory-bank/agentLog.md
@@ -601,3 +601,27 @@ bundled `agency-categories.json` (no drift). Then wired the app to read it direc
 - Tests: +4 (missing→bundled, malformed→bundled, overlay override+net-new+retain-omitted, unknown-slug
   fallback); updated the bundled-json test to use `category_meta_from`. cargo lib 262/0, no warnings. GOTCHA:
   raw string with hex colors needs `r##"…"##` (a `"#` closes `r#"…"#`).
+
+## 2026-06-15 (later 7) — catalog #593 (integrations purge), strategy-docs finding, default-landing fix
+- **Renderer parity "failure" was a CATALOG data issue, NOT a render bug.** PR #5's matrix run hit a Codex
+  parity mismatch on `design/design-brand-guardian.md`. Root cause: the catalog clone had been pulled to
+  upstream `main` (232→**748** files), and `integrations/` (957 files: openclaw 427, opencode 232,
+  antigravity 143, qwen 143, …) is COMMITTED per-tool CONVERSIONS, yet `integrations` was in `AGENT_DIRS` →
+  convert.sh re-converts them → slug COLLISIONS (`brand-guardian` ×3, last-writer-wins) → the harness compared
+  render's real-agent output to a different agent's file. `render/mod.rs` is faithful — unchanged.
+  **Fixed UPSTREAM** by the catalog: PR #593 (`3f78a30`) drops `integrations` from `AGENT_DIRS` AND removes it
+  from `divisions.json` (→ 17 divisions). Clone pulled; app reads `AGENT_DIRS` live and `build_from_dir` scopes
+  its scan to `dir.join(category)`, so integrations/ is no longer touched (relaunch log: 0 integrations
+  warnings).
+- **Strategy is NOT 16 agents.** `strategy/` = 16 NEXUS *docs* (QUICKSTART/EXECUTIVE-BRIEF/nexus-strategy +
+  coordination/runbooks/playbooks phase-0..6) — all start with `#`, none have a `---` frontmatter fence, so
+  `parse_agent`→`Ok(None)` skips every one. Persisted `corpus-index.json` confirms **strategy = 0**; real
+  catalog = 16 divisions / 232 agents (specialized 53 … product 5). Zero-count divisions hide.
+- **Default-landing setting fix** (Settings→Appearance "open on" did nothing): `loadDefaultSectionFromStorage`
+  guarded `if (this.section === "dashboard")` but the home screen had moved to `personas`, so the saved default
+  loaded into `defaultSection` but was never applied to `section`. FIX: a shared `INITIAL_SECTION = "personas"`
+  const used by BOTH the `section` initializer and the guard, so they can't drift again. `src/lib/stores/ui.svelte.ts`,
+  svelte-check 0. Loader is wired at `+layout.svelte:18` onMount.
+- **PENDING (pre-release hygiene):** app's bundled `agency-categories.json` still lists `integrations` (18) vs
+  upstream `divisions.json` (17) — harmless (never iterated; `category_order` excludes it) but should sync;
+  consider also dropping `strategy` from the division set (0 agents). Then we're clear to cut **v0.1.0**.

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -92,11 +92,20 @@ const SECTION_TITLES: Record<SidebarSection, string> = {
   activity:  "Activity",
 };
 
+/** The hardcoded first-launch section, before any saved default-landing or
+    navigation is applied. `loadDefaultSectionFromStorage` uses this as the
+    "untouched" sentinel: it only applies the saved default when `section` is
+    still this value (i.e. nothing else has routed yet). Keeping it in one
+    constant prevents the guard from drifting away from the initializer — the
+    exact bug where the home screen moved to `personas` but the guard still
+    checked for `dashboard`, silently disabling the default-landing setting. */
+const INITIAL_SECTION: SidebarSection = "personas";
+
 class UiStore {
   /** First-launch landing. The Agents (personas) catalog is the home screen —
       the agent catalog is the front door, not the Dashboard. Clicking the
       sidebar brand returns here. */
-  section: SidebarSection = $state("personas");
+  section: SidebarSection = $state(INITIAL_SECTION);
 
   /** The active section's display name — shown in the window title bar
       (the panel-head `<h1>` was removed in favour of the title bar). */
@@ -310,7 +319,7 @@ class UiStore {
 
   /** On first paint, read the saved default-landing and (if the user
       hasn't already navigated) override `section`. We treat the hardcoded
-      Dashboard default as "untouched" — if some early code already routed
+      `INITIAL_SECTION` as "untouched" — if some early code already routed
       the user elsewhere we leave it alone. Validates against the known
       enum on read per Phase 12 security review § 12b. */
   loadDefaultSectionFromStorage() {
@@ -320,8 +329,8 @@ class UiStore {
         const validated = v as SidebarSection;
         this.defaultSection = validated;
         // Only override the initial section if it's still the hardcoded
-        // dashboard default — anything else means something already routed.
-        if (this.section === "dashboard") {
+        // landing — anything else means something already routed.
+        if (this.section === INITIAL_SECTION) {
           this.section = validated;
         }
       }


### PR DESCRIPTION
## What

The **Settings → Appearance → default landing** setting did nothing — the app always opened on Agents regardless of the saved choice.

## Root cause

`loadDefaultSectionFromStorage` only applied the saved default when `section === "dashboard"`. But the home screen was moved to `"personas"` (the `section` initializer), so that guard never matched. The saved value loaded into `defaultSection` but was never copied to the active `section`.

## Fix

A single `INITIAL_SECTION = "personas"` constant drives **both** the `section` initializer and the guard, so they can't drift apart again. Now a saved default (Dashboard / Tools / Loadouts / Activity) applies at launch, as long as nothing else routed first.

svelte-check: 0 errors. Loader is wired at `+layout.svelte:18` (onMount).

🤖 Generated with [Claude Code](https://claude.com/claude-code)