### PR TITLE
chore(corpus): sync bundled division floor with catalog divisions.json

### DIFF
--- a/src-tauri/data/agency-categories.json
+++ b/src-tauri/data/agency-categories.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Division (category) label+icon+color metadata for the Agency Agents corpus. Mirrors the catalog repo's divisions.json. Icons are Lucide PascalCase names; colors are hex. Read by src/corpus/mod.rs::category_meta.",
+  "_note": "Division (category) label+icon+color metadata for the Agency Agents corpus. Mirrors the catalog repo's divisions.json (the canonical source; this is the bundled floor for first-run / pre-sync clones). Icons are Lucide PascalCase names; colors are hex. Read by src/corpus/mod.rs (load_division_meta / bundled_division_meta).",
   "categories": {
     "academic": { "label": "Academic", "icon": "GraduationCap", "color": "#8B5CF6" },
     "design": { "label": "Design", "icon": "PenTool", "color": "#EC4899" },
@@ -7,7 +7,6 @@
     "finance": { "label": "Finance", "icon": "DollarSign", "color": "#22C55E" },
     "game-development": { "label": "Game Development", "icon": "Gamepad2", "color": "#A855F7" },
     "gis": { "label": "GIS", "icon": "Map", "color": "#14B8A6" },
-    "integrations": { "label": "Integrations", "icon": "Workflow", "color": "#64748B" },
     "marketing": { "label": "Marketing", "icon": "Megaphone", "color": "#F97316" },
     "paid-media": { "label": "Paid Media", "icon": "Target", "color": "#EAB308" },
     "product": { "label": "Product", "icon": "Box", "color": "#D946EF" },


### PR DESCRIPTION
Regenerate the bundled `agency-categories.json` directly from the catalog's `divisions.json` so the floor mirrors the canonical source exactly.

- **17 divisions** (was 18) — drops `integrations`, which catalog PR #593 removed from the source set (it's convert.sh output, not a real division).
- **Zero drift** on label/icon/color for the shared 17; `strategy` retained (present in `divisions.json`).
- The floor is what first-run users and pre-sync clones see; keeping it identical to upstream prevents the bundled copy from re-introducing a stale division.

cargo corpus tests: 32 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)