### PR TITLE
ci: native Linux + Windows build workflows; updater domain -> agencyagents.app

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,96 @@
+# Linux build — produces Agency Agents' .deb / .rpm / .AppImage bundles on a
+# native x86_64 runner (no emulation, so the AppImage bundler works cleanly).
+#
+# Tauri 2 builds all three Linux bundle targets via `npm run tauri build`
+# (which runs the SvelteKit frontend build first via beforeBuildCommand).
+#
+# Signing: Linux desktop has no code-signing requirement for v0.1.0 — AppImage
+# ships unsigned (the common convention); .deb/.rpm GPG signing is a future
+# optional step. Updater artifacts are disabled here (v0.1.0 ships with
+# SKIP_UPDATER; auto-update is deferred), so no signing key is needed.
+#
+# Output: .deb / .rpm / .AppImage uploaded to the workflow run. Cutting the
+# GitHub Release + attaching artifacts remains a deliberate human step.
+
+name: Linux Build
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Linux bundles (.deb / .rpm / .AppImage)
+    # Pin to ubuntu-22.04 (Jammy, webkit2gtk-4.1) for the oldest glibc we
+    # commit to supporting — binaries run on 22.04+; ubuntu-latest would
+    # silently raise the floor.
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Standard Tauri 2 Linux build deps (https://v2.tauri.app/start/prerequisites/)
+      # plus patchelf/file/wget for the AppImage bundler, and the xdg-utils +
+      # gtk/rsvg helpers the AppImage GTK plugin shells out to.
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev \
+            build-essential \
+            file \
+            wget \
+            xdg-utils \
+            librsvg2-bin \
+            libgtk-3-bin
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      # Builds the frontend, compiles the Rust binary, and bundles
+      # .deb / .rpm / .AppImage. Updater artifacts disabled (v0.1.0).
+      - name: Build Tauri app
+        run: npm run tauri build -- --config '{"bundle":{"createUpdaterArtifacts":false}}'
+
+      - name: Upload .deb
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-agents-deb
+          path: src-tauri/target/release/bundle/deb/*.deb
+          if-no-files-found: error
+
+      - name: Upload .rpm
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-agents-rpm
+          path: src-tauri/target/release/bundle/rpm/*.rpm
+          if-no-files-found: error
+
+      - name: Upload .AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-agents-appimage
+          path: src-tauri/target/release/bundle/appimage/*.AppImage
+          if-no-files-found: error

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,74 @@
+# Windows build — produces Agency Agents' NSIS installers for x64 and arm64
+# on a native windows-latest (x64) runner. arm64 is cross-compiled in-OS via
+# the aarch64-pc-windows-msvc target (the same trick the local VM matrix uses),
+# so one runner yields both installers.
+#
+# Signing: DEFERRED for v0.1.0 (see memory-bank/decisions.md 2026-06-16). The
+# installers are unsigned, so Windows SmartScreen warns on first launch
+# ("More info -> Run anyway"). When a code-signing cert (EV or Azure Trusted
+# Signing) is in place, signing slots in after each build step. Updater
+# artifacts are disabled (auto-update deferred), so no signing key is needed.
+#
+# Output: the x64 + arm64 NSIS .exe installers uploaded to the workflow run.
+
+name: Windows Build
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Windows installers (x64 + arm64, unsigned)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable (+ arm64 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-pc-windows-msvc
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      # x64 (native). Updater artifacts disabled (v0.1.0). shell: bash so the
+      # --config JSON survives quoting (Windows runners ship Git Bash).
+      - name: Build x64 installer
+        shell: bash
+        run: npm run tauri build -- --target x86_64-pc-windows-msvc --config '{"bundle":{"createUpdaterArtifacts":false}}'
+
+      # arm64 (cross-compiled in-OS). The frontend is already built; this just
+      # recompiles the Rust binary for arm64 and bundles its NSIS installer.
+      - name: Build arm64 installer
+        shell: bash
+        run: npm run tauri build -- --target aarch64-pc-windows-msvc --config '{"bundle":{"createUpdaterArtifacts":false}}'
+
+      - name: Upload x64 installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-agents-windows-x64
+          path: src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*-setup.exe
+          if-no-files-found: error
+
+      - name: Upload arm64 installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: agency-agents-windows-arm64
+          path: src-tauri/target/aarch64-pc-windows-msvc/release/bundle/nsis/*-setup.exe
+          if-no-files-found: error

--- a/scripts/release-linux.sh
+++ b/scripts/release-linux.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# release-linux.sh — build Linux desktop bundles (.deb / .rpm / .AppImage) for
+# Agency Agents inside a Docker container, so they can be produced from a Mac
+# (or any Docker host) without a native Linux machine.
+#
+#   ./scripts/release-linux.sh            # x86_64 (default; QEMU-emulated on Apple Silicon)
+#   PLATFORM=linux/arm64 ./scripts/release-linux.sh   # native arm64 on an Apple-Silicon Mac
+#
+# Why a container: Tauri's Linux bundling links native GTK/WebKitGTK and uses
+# Linux-only packagers (dpkg-deb, rpmbuild, appimagetool), so it must run on
+# Linux. On Apple Silicon, `--platform linux/amd64` runs the x86_64 toolchain
+# under QEMU — correct output, just slow.
+#
+# Artifacts land in dist/linux-<arch>/. Unsigned (standard for Linux desktop).
+# Updater artifacts are disabled (matches SKIP_UPDATER=1 for the macOS DMG).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLATFORM="${PLATFORM:-linux/amd64}"
+ARCH_TAG="$(printf '%s' "$PLATFORM" | sed 's#linux/##')"
+OUT="$ROOT/dist/linux-${ARCH_TAG}"
+IMAGE="ubuntu:22.04"
+
+mkdir -p "$OUT"
+
+echo "▸ Building Linux bundles for $PLATFORM (image $IMAGE)"
+echo "  repo: $ROOT"
+echo "  out:  $OUT"
+echo "  (QEMU emulation is slow for non-native arches — be patient.)"
+
+docker run --rm --platform "$PLATFORM" \
+  -v "$ROOT":/src:ro \
+  -v "$OUT":/out \
+  -e DEBIAN_FRONTEND=noninteractive \
+  -e APPIMAGE_EXTRACT_AND_RUN=1 \
+  "$IMAGE" bash -euo pipefail -c '
+    echo "::deps"
+    apt-get update -qq
+    apt-get install -y -qq --no-install-recommends \
+      curl wget file ca-certificates rsync xz-utils \
+      build-essential pkg-config \
+      libwebkit2gtk-4.1-dev librsvg2-dev libssl-dev \
+      libayatana-appindicator3-dev libxdo-dev \
+      patchelf rpm fakeroot \
+      xdg-utils librsvg2-bin libgtk-3-bin >/dev/null
+    # ^ xdg-utils (xdg-open), librsvg2-bin (rsvg-convert), libgtk-3-bin
+    #   (gtk-update-icon-cache) are needed by the AppImage GTK bundler.
+
+    echo "::node"
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - >/dev/null 2>&1
+    apt-get install -y -qq nodejs >/dev/null
+    echo "  node $(node -v) / npm $(npm -v)"
+
+    echo "::rust"
+    curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal >/dev/null 2>&1
+    . "$HOME/.cargo/env"
+    echo "  $(rustc --version)"
+
+    echo "::copy source (excluding host build dirs)"
+    rsync -a \
+      --exclude .git --exclude node_modules --exclude dist \
+      --exclude target --exclude src-tauri/target \
+      --exclude .svelte-kit --exclude build --exclude .phase-c \
+      /src/ /build/
+    cd /build
+
+    echo "::npm ci"
+    npm ci --no-audit --no-fund
+
+    echo "::tauri build (deb, rpm, appimage; no updater artifacts)"
+    set +e
+    npm run tauri build -- \
+      --bundles deb,rpm,appimage \
+      --config "{\"bundle\":{\"createUpdaterArtifacts\":false}}"
+    BUILD_RC=$?
+    set -e
+
+    # Collect whatever bundled, even on partial failure, so one broken bundler
+    # never discards the others with the container.
+    echo "::collect (build rc=$BUILD_RC)"
+    find src-tauri/target -path "*/release/bundle/*" \
+      \( -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" \) \
+      -exec cp -v {} /out/ \; || true
+
+    exit $BUILD_RC
+  '
+
+echo ""
+echo "✓ Linux ($ARCH_TAG) bundles:"
+ls -lh "$OUT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,13 +23,13 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https://api.github.com https://github.com https://codeload.github.com https://objects.githubusercontent.com https://raw.githubusercontent.com https://agency-agents-app.zerologic.com; img-src 'self' data: https://raw.githubusercontent.com https://avatars.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+      "csp": "default-src 'self'; connect-src 'self' https://api.github.com https://github.com https://codeload.github.com https://objects.githubusercontent.com https://raw.githubusercontent.com https://agencyagents.app; img-src 'self' data: https://raw.githubusercontent.com https://avatars.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
     }
   },
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://agency-agents-app.zerologic.com/updater.json"
+        "https://agencyagents.app/updater.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDczMzVERDBGRDAzQTRBNkEKUldScVNqclFEOTAxYy9DYTg5QThJR2JWWHJZSWdWMXRkckFlUDAyVHpxcjgwWXVHaUQ2VlNGcHgK"
     }


### PR DESCRIPTION
## CI workflows (native runners, no emulation)

- **`linux-build.yml`** — `ubuntu-22.04` → `.deb` / `.rpm` / **`.AppImage`** (native x64, so the AppImage bundler works cleanly — unlike local Docker emulation). Pinned to 22.04 for the glibc floor.
- **`windows-build.yml`** — `windows-latest` → **x64 + arm64 NSIS installers** from one runner (arm64 cross-compiled in-OS via `aarch64-pc-windows-msvc`). **Unsigned**, per the v0.1.0 signing-deferral decision (ships with the SmartScreen note).

Both fire on `v*` tags + manual dispatch, and disable updater artifacts (auto-update deferred for v0.1.0, so no signing key needed). macOS DMGs stay a local signed/notarized build (`scripts/release.sh`).

## Domain swap

`tauri.conf.json` updater endpoint + CSP `connect-src` → `https://agencyagents.app` (bundle id unchanged). Matches the now-live landing host.

## Also

`scripts/release-linux.sh` — a Docker-based local Linux build (works natively on an x64 host; AppImage needs a native x64 box, not QEMU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)