### PR TITLE
docs: post-v0.1.0 — Homebrew install + macOS beta build troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,18 @@ The upstream AA repo also contains integrations for Antigravity, Aider, Windsurf
 
 ## Install
 
-Release packaging is still pre-1.0.
+Grab the build for your platform from the [latest release](https://github.com/msitarzewski/agency-agents-app/releases/latest):
+
+- **macOS** (Apple Silicon & Intel) — signed + notarized `.dmg`, macOS 13+.
+- **Linux** (x86_64) — `.deb`, `.rpm`, or the portable `.AppImage`.
+- **Windows** (x64 & ARM64) — `.exe` installer (not code-signed yet; SmartScreen → *More info → Run anyway*).
+
+Or on macOS via Homebrew:
+
+```sh
+brew tap msitarzewski/agency-agents
+brew install --cask agency-agents
+```
 
 For local review, use the development app:
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -189,6 +189,44 @@ See [docs/icon/README-liquid-glass.md](./icon/README-liquid-glass.md).
 - Windows Intel and ARM builds should be verified as separate artifacts.
 - Linux packages should be smoke-tested in the Ubuntu VM before claiming support.
 
+## Troubleshooting: proc-macro "can't find crate" on a beta macOS
+
+On a **beta macOS / Xcode** (first hit on macOS 26/27 Tahoe beta during the v0.1.0 cut), `scripts/release.sh` can fail with:
+
+```
+error[E0463]: can't find crate for `ctor_proc_macro`   (or tauri_macros / serde_with_macros / …)
+```
+
+**Root cause:** the Tauri CLI sets `MACOSX_DEPLOYMENT_TARGET` (from `bundle.macOS.minimumSystemVersion`, `13.0`) before invoking cargo, and on the beta toolchain that breaks *fresh* proc-macro dylib compilation. The exact same `cargo build --bins --features tauri/custom-protocol --release` succeeds **bare** (no `MACOSX_DEPLOYMENT_TARGET`) and on the **CI runners** (stable macOS) — so prefer CI for releases when possible. It is non-deterministic (a different proc-macro fails each run) and is NOT a code problem.
+
+**Local recovery** — pre-compile the crate graph (incl. proc-macros) *without* `MACOSX_DEPLOYMENT_TARGET`, using Tauri's exact config so it won't recompile, then let `release.sh` bundle/sign/notarize off the warm cache (proc-macro fingerprints don't include `MACOSX_DEPLOYMENT_TARGET`, so they're reused):
+
+```sh
+# 1. Capture the exact TAURI_CONFIG the CLI passes to cargo (one-shot; the run
+#    is expected to fail at a proc-macro — we only need the dumped value).
+cat > /tmp/dump.sh <<'W'
+#!/bin/bash
+[ -f /tmp/tc.txt ] || printf '%s' "$TAURI_CONFIG" > /tmp/tc.txt
+exec "$@"
+W
+chmod +x /tmp/dump.sh; rm -f /tmp/tc.txt
+RUSTC_WRAPPER=/tmp/dump.sh npm run tauri build -- --config '{"bundle":{"createUpdaterArtifacts":false}}' >/dev/null 2>&1 || true
+TC=$(cat /tmp/tc.txt)
+
+# 2. Per arch: pre-build WITHOUT MACOSX_DEPLOYMENT_TARGET, then bundle.
+#    (For the non-host arch, use a rustup toolchain that has the target's std.)
+rm -rf src-tauri/target
+env -u MACOSX_DEPLOYMENT_TARGET TAURI_CONFIG="$TC" \
+  cargo build --bins --features tauri/custom-protocol --release   # host arch
+SKIP_UPDATER=1 RELEASE_TARGETS="aarch64-apple-darwin" ./scripts/release.sh
+
+env -u MACOSX_DEPLOYMENT_TARGET TAURI_CONFIG="$TC" \
+  cargo build --bins --features tauri/custom-protocol --release --target x86_64-apple-darwin
+SKIP_UPDATER=1 RELEASE_TARGETS="x86_64-apple-darwin" ./scripts/release.sh
+```
+
+The cleaner long-term fix is to cut macOS releases on a stable macOS box or a macOS CI runner. (Homebrew/CLT vs rustup also matters for the x86_64 cross — that target's std lives in the rustup toolchain; put `~/.rustup/toolchains/stable-<host>/bin` first on `PATH`.)
+
 ## Secrets
 
 Never commit signing credentials, updater private keys, GitHub tokens, or notary credentials. Use local keychain items or files outside the repo with `0600` permissions.

--- a/landing/index.html
+++ b/landing/index.html
@@ -198,6 +198,10 @@
         <li><strong>Windows (x64 / ARM64).</strong> the <code>.exe</code> installer. Not code-signed yet — on first launch SmartScreen shows "Windows protected your PC"; click <strong>More info → Run anyway</strong>.</li>
         <li><strong>Linux.</strong> <code>.deb</code> (Debian/Ubuntu), <code>.rpm</code> (Fedora/RHEL/openSUSE), or the portable <code>.AppImage</code>.</li>
       </ul>
+      <p>Or install with <strong>Homebrew</strong> (macOS):</p>
+      <pre><code>brew tap msitarzewski/agency-agents
+brew install --cask agency-agents</code></pre>
+      <p class="small-note">Installs the signed &amp; notarized <code>.dmg</code> (Apple Silicon or Intel, auto-selected). Upgrade with <code>brew upgrade --cask agency-agents</code>.</p>
       <p>Or build it yourself from source:</p>
       <pre><code>git clone https://github.com/msitarzewski/agency-agents-app
 cd agency-agents-app

--- a/memory-bank/agentLog.md
+++ b/memory-bank/agentLog.md
@@ -625,3 +625,26 @@ bundled `agency-categories.json` (no drift). Then wired the app to read it direc
 - **PENDING (pre-release hygiene):** app's bundled `agency-categories.json` still lists `integrations` (18) vs
   upstream `divisions.json` (17) — harmless (never iterated; `category_order` excludes it) but should sync;
   consider also dropping `strategy` from the division set (0 agents). Then we're clear to cut **v0.1.0**.
+
+## 2026-06-16 — v0.1.0 SHIPPED (cross-platform, signed) + repo PUBLIC + Homebrew tap
+Cut the first public release: **github.com/msitarzewski/agency-agents-app/releases/tag/v0.1.0**, all 7 artifacts.
+- **macOS** aarch64 + x64 DMGs — signed + **notarized** (spctl: accepted / Notarized Developer ID; stapler ok).
+  Built locally via `scripts/release.sh` (dual-arch; host native, x64 cross via rustup).
+- **Linux** deb/rpm/AppImage (x86_64) + **Windows** x64/arm64 NSIS — built by NEW GitHub Actions workflows
+  (`linux-build.yml`, `windows-build.yml`) on native runners, downloaded + attached to the release.
+- PRs this session: #3–#8 (dashboard/landing/CI/domain/docs), #9 landing, #10 CI+domain, #11 release-prep.
+  Tagged `v0.1.0` → CI fired → assembled the GitHub release with `gh release create`.
+- **Repo made PUBLIC** (was private — that's why release-asset `browser_download_url`s 404'd for Homebrew/the
+  public; `gh` auth-download worked, masking it). Pre-flight secret scan: gitleaks 50 commits → **1 FALSE
+  POSITIVE** (AGENTS.md "Context Exceeded" prose); no secret files in history; `.gitignore` covers `.env*`/`*.key`;
+  notary pw + updater private key live in Keychain (never committed). Clean → public.
+- **Homebrew tap**: NEW repo `msitarzewski/homebrew-agency-agents` with `Casks/agency-agents.rb` (dual-arch,
+  installs the notarized DMG). `brew tap msitarzewski/agency-agents && brew install --cask agency-agents`.
+  Audited online (download + sha ok). README/landing got download + brew-install sections; landing redeployed.
+- **⚠️ HARD-WON MACOS BUILD GOTCHA** (cost ~2h of debugging): on macOS 27 Tahoe BETA + Xcode BETA, the Tauri CLI
+  sets `MACOSX_DEPLOYMENT_TARGET=13.0` (from `minimumSystemVersion`), which breaks FRESH proc-macro compilation
+  ("can't find crate for ctor_proc_macro/tauri_macros/…", non-deterministic). The identical cargo cmd works
+  **bare** (no that env) + on **CI** (stable). Fix: pre-compile without `MACOSX_DEPLOYMENT_TARGET` (proc-macro
+  fingerprints don't include it), then Tauri reuses the cache to bundle. Full recipe in `docs/BUILD.md`
+  ("Troubleshooting: proc-macro 'can't find crate' on a beta macOS") + [[macos-beta-macosx-deployment-target-breaks-proc-macros]].
+  Red herrings ruled out: toolchain, linker, Xcode CLT-vs-beta, PATH/node shims, ulimit (1M), disk (5TB), RAM (128GB).

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -71,18 +71,35 @@ else
 fi
 
 # Build BOTH macOS architectures so we ship Apple Silicon + Intel DMGs. Each
-# `--target` build signs with your Developer ID, notarizes, and staples, and
-# writes to src-tauri/target/<triple>/release/bundle/ (per-arch). Override with
-# e.g. RELEASE_TARGETS="aarch64-apple-darwin" to build a single arch.
+# build signs with your Developer ID, notarizes, and staples. The HOST arch
+# builds natively into target/release/bundle/; other arches cross-compile into
+# target/<triple>/release/bundle/. Override the set with e.g.
+# RELEASE_TARGETS="aarch64-apple-darwin x86_64-apple-darwin".
+#
+# ⚠️ macOS BETA TOOLCHAIN GOTCHA: on a beta macOS/Xcode (e.g. Tahoe/26+), this
+# build can fail with "can't find crate for <proc-macro>" (ctor_proc_macro,
+# tauri_macros, serde_with_macros, …). Root cause: the MACOSX_DEPLOYMENT_TARGET
+# the Tauri CLI sets (from minimumSystemVersion) breaks FRESH proc-macro
+# compilation under the beta toolchain. Stable macOS / CI are unaffected.
+# Recovery (pre-compile proc-macros without that env var, then let Tauri reuse
+# the cache to bundle/sign/notarize) is documented in docs/BUILD.md →
+# "Troubleshooting: proc-macro 'can't find crate' on a beta macOS".
 read -r -a TARGETS <<< "${RELEASE_TARGETS:-aarch64-apple-darwin x86_64-apple-darwin}"
+HOST_TRIPLE="$(rustc -vV | awk '/^host:/{print $2}')"
+DMG_DIRS=()
 
 for target in "${TARGETS[@]}"; do
-  echo "▸ Building signed + notarized Agency Agents for ${target} (Team $APPLE_TEAM_ID)…"
-  npm run tauri build -- --target "$target" "${BUILD_ARGS[@]}"
+  if [[ "$target" == "$HOST_TRIPLE" ]]; then
+    echo "▸ Building signed + notarized Agency Agents for ${target} (native, Team $APPLE_TEAM_ID)…"
+    npm run tauri build -- "${BUILD_ARGS[@]}"
+    DMG_DIRS+=("src-tauri/target/release/bundle/dmg/")
+  else
+    echo "▸ Building signed + notarized Agency Agents for ${target} (cross, Team $APPLE_TEAM_ID)…"
+    npm run tauri build -- --target "$target" "${BUILD_ARGS[@]}"
+    DMG_DIRS+=("src-tauri/target/${target}/release/bundle/dmg/")
+  fi
 done
 
 echo
 echo "✓ Done. Signed + notarized DMGs:"
-for target in "${TARGETS[@]}"; do
-  echo "    src-tauri/target/${target}/release/bundle/dmg/"
-done
+for d in "${DMG_DIRS[@]}"; do echo "    $d"; done


### PR DESCRIPTION
Homebrew install path (landing + README), README Install updated for the shipped v0.1.0, and the hard-won `MACOSX_DEPLOYMENT_TARGET` proc-macro gotcha + recovery recipe documented in `docs/BUILD.md` and `release.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)