### PR TITLE
fix(macos): polished DMG window layout (next release)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,7 +52,12 @@
     "macOS": {
       "signingIdentity": "Developer ID Application: Michael Sitarzewski (7JQGQ7CRH8)",
       "hardenedRuntime": true,
-      "minimumSystemVersion": "13.0"
+      "minimumSystemVersion": "13.0",
+      "dmg": {
+        "windowSize": { "width": 540, "height": 380 },
+        "appPosition": { "x": 140, "y": 190 },
+        "applicationFolderPosition": { "x": 400, "y": 190 }
+      }
     }
   }
 }


### PR DESCRIPTION
First-user feedback: the mounted DMG window was Tauri's bare default. Give it a 540×380 window with the app at left and Applications at right. Cosmetic; lands on the next release build (v0.1.0 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)