### PR TITLE
Two-pane Deploy browser + wide install modal

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -10,19 +10,42 @@ Now on **v0.1.1 dev**. Full launch log: `agentLog.md` 2026-06-16.
 
 **Workflow (from 2026-06-16):** ALL changes go through a **branch → PR → merge to `main`**. No direct commits to main.
 
-## 🔵 NEXT FEATURE (v0.1.1 #1) — Divisions landing + bulk install/remove by division
-Change the **Agents panel landing** to a **list of divisions** (not individual agents) with the same **select**
-(multi-select / "Select" mode) behavior the agent list already has, so users can act on **whole divisions**:
-- Landing = the division list (each row = a division, count, color/icon). Multi-select rows.
-- **"Install Selected"** → opens a **modal listing the available tools**; the user picks tool(s), and the app
-  installs **every agent in the selected division(s)** into those tools.
-- **Remove / Delete** → the same flow: select divisions → modal → remove/uninstall all those agents from the
-  chosen tool(s) (respect the adaptive Uninstall-vs-Delete ownership wording + backup-on-delete safety).
-- Reuse the existing select-mode bulk UI in `AgentsWorkspace.svelte`, the per-tool install plumbing in
-  `install.svelte.ts` / `install/mod.rs`, division metadata via `corpus.colorOf/iconOf/labelOf`, and the
-  Switch/tool-target components. Drilling into a division should still reach the per-agent list.
+## ✅ v0.1.1 IA arc — SHIPPED (2026-06-17 → 06-20, PRs #15 + #16, + the deploy-browser PR)
+The whole "how people think about agents" reorganization landed:
+- **Divisions landing** — the Agents tab opens on divisions; select-mode → bulk deploy.
+- **Install-state lens** — filter the agent list by deployment state (In sync / Outdated / Untracked / Missing /
+  Not installed), counts scoped to the division.
+- **Teams** (renamed from Loadouts) — "Your team" (current installs, division-grouped) + "Team presets"
+  (app-bundled `presetTeams.ts` + your saved teams, `teams.svelte.ts`).
+- **how × where engine** (backend, PR #15) — tools are dual-scope; `render::dests()` scope-aware;
+  `supports_user()`/`supports_project()`; install scope derived from the chosen project. Verified tool-path
+  matrix (June 2026) in the PR. Cursor is project-only; Windsurf/Aider/Antigravity/openclaw deferred.
+- **Projects pillar** (4th nav section, ⌘4; Activity → ⌘5) — `projects.svelte.ts` store (registered roots in
+  localStorage ∪ the live ledger), `Projects.svelte` panel with rosters.
+- **One `InstallModal`** — the destinations × tools GRID (rows = Global + each project + "Add project…",
+  columns = detected tools, cells = tri-state toggles). Reused by agent detail, divisions, Teams, Projects.
+  Replaced `DeployModal` + the inline switch-matrix. Agent detail: "Install…" in the title, pills on their own row.
+- **Two-pane `DeployBrowser.svelte`** (Projects "Deploy…") — System-Settings master/detail: left =
+  searchable list of EVERY granularity (agents · divisions · teams incl. saved · current roster); right =
+  per-project per-tool install.
 
-**Last updated**: 2026-06-16
+**Four-pillar model (drives IA copy):** Agents = *who* · Tools = *how* · Teams = *which* · Projects = *where*.
+
+## 🔵 Backlog (next)
+- **InstallModal → pick from existing Projects + "New Project…"** (instead of the inline folder-picker; now
+  that Projects is a managed list). [raised 2026-06-20]
+- **"Auto Updates" subscription** for bulk installs — installing all of a division/team into a project/tool
+  offers to auto-deploy newly-added catalog agents.
+- **Copilot `.md` → `.agent.md`** (needs reconcile `file_stem` double-extension handling).
+- Optionally tighten backend `detect()` to require the tool **binary**, not just a lingering config dir.
+- Bonus: a "scaffold AGENT-ZERO into a project" action (every assistant honors repo-root `AGENTS.md`).
+
+**Dev-harness note:** to screenshot-verify the Svelte frontend in a browser (the native Tauri window can't be
+auto-driven), a `?shim=1` Tauri-IPC shim is temporarily injected into `src/app.html` then reverted — it never
+ships. The shim can't open a real native folder dialog (returns a fixture path), so "Add project…" looks broken
+in the shim though it works natively.
+
+**Last updated**: 2026-06-20
 
 ## ✅ Pre-release polish (2026-06-15) — committed + pushed on `release-planning`
 - **brew vestige cleanup**: error-type rename (`BrewError*`→`AppError*`), removed dead `catalogAutoRefresh`

--- a/src/lib/components/DeployBrowser.svelte
+++ b/src/lib/components/DeployBrowser.svelte
@@ -1,0 +1,390 @@
+<script lang="ts">
+  /**
+   * DeployBrowser — a two-pane "deploy into a project" picker (System-Settings
+   * style). The LEFT pane is a scrollable list of things you can drop into the
+   * project — the project's current roster, the app presets, and every division.
+   * Clicking one shows it on the RIGHT: its agents + a per-tool installer scoped
+   * to THIS project. Replaces the old flat chooser → modal hop.
+   *
+   * The right-pane toggles are tri-state over the selected set (all / some /
+   * none) for each project-capable tool, scoped to this project's path; removal
+   * of `foreign` files asks first.
+   */
+  import { onMount } from "svelte";
+  import X from "@lucide/svelte/icons/x";
+  import FolderIcon from "@lucide/svelte/icons/folder";
+  import LayersIcon from "@lucide/svelte/icons/layers";
+  import UsersIcon from "@lucide/svelte/icons/users";
+
+  import Input from "./Input.svelte";
+  import DestructiveConfirm from "./DestructiveConfirm.svelte";
+  import { corpus } from "$lib/stores/corpus.svelte";
+  import { install, SUPPORTED_TOOLS } from "$lib/stores/install.svelte";
+  import { teams } from "$lib/stores/teams.svelte";
+  import { toast } from "$lib/stores/toast.svelte";
+  import { resolveCategoryIcon } from "$lib/util/categoryIcon";
+  import { PRESET_TEAMS } from "$lib/data/presetTeams";
+  import type { Tool, InstalledAgent } from "$lib/types";
+  import type { Component as SvelteComponent } from "svelte";
+
+  interface Props {
+    projectPath: string;
+    onClose: () => void;
+  }
+  let { projectPath, onClose }: Props = $props();
+
+  onMount(() => {
+    corpus.ensureLoaded();
+    teams.hydrate();
+    void install.reconcile();
+  });
+
+  let query = $state("");
+
+  function basename(p: string): string {
+    return p.replace(/\/+$/, "").split("/").pop() || p;
+  }
+  const projectName = $derived(basename(projectPath));
+
+  // ── Left list: current roster + presets + divisions ──
+  type Item = {
+    key: string;
+    label: string;
+    description: string;
+    /** Lucide component icon OR an emoji string (agents). */
+    icon?: SvelteComponent;
+    emoji?: string;
+    color: string | null;
+    slugs: string[];
+  };
+
+  const rosterSlugs = $derived([
+    ...new Set(
+      install.installed
+        .filter((r) => r.state !== "removed" && (r.projectPath ?? null) === projectPath)
+        .map((r) => r.slug),
+    ),
+  ]);
+
+  // Every deployable granularity — an agent, a division, a team (preset OR your
+  // own saved team), or the project's current roster.
+  const presetItems = $derived<Item[]>(
+    PRESET_TEAMS.map((p) => ({ key: `preset:${p.slug}`, label: p.label, description: p.description, icon: p.icon as unknown as SvelteComponent, color: p.color, slugs: p.agents })),
+  );
+  const savedTeamItems = $derived<Item[]>(
+    teams.saved.map((t) => ({ key: `team:${t.id}`, label: t.name, description: `${t.agents.length} agent${t.agents.length === 1 ? "" : "s"} · saved`, icon: UsersIcon as unknown as SvelteComponent, color: null, slugs: t.agents })),
+  );
+  const divisionItems = $derived<Item[]>(
+    corpus.tiles.map((c) => ({ key: `div:${c.slug}`, label: c.label, description: `${c.count} agent${c.count === 1 ? "" : "s"}`, icon: resolveCategoryIcon(c.icon) as unknown as SvelteComponent, color: corpus.colorOf(c.slug), slugs: corpus.agents.filter((a) => a.category === c.slug).map((a) => a.slug) })),
+  );
+  const agentItems = $derived<Item[]>(
+    corpus.agents.map((a) => ({ key: `agent:${a.slug}`, label: a.name, description: corpus.labelOf(a.category), emoji: a.emoji ?? "🧩", color: null, slugs: [a.slug] })),
+  );
+
+  function match(items: Item[]): Item[] {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((i) => `${i.label} ${i.description}`.toLowerCase().includes(q));
+  }
+
+  const groups = $derived(
+    [
+      rosterSlugs.length > 0 && !query.trim()
+        ? {
+            head: "This project",
+            items: [
+              {
+                key: "roster",
+                label: "Current roster",
+                description: `${rosterSlugs.length} agent${rosterSlugs.length === 1 ? "" : "s"} already here`,
+                icon: FolderIcon as unknown as SvelteComponent,
+                color: null,
+                slugs: rosterSlugs,
+              } satisfies Item,
+            ],
+          }
+        : null,
+      { head: "Teams", items: match([...savedTeamItems, ...presetItems]) },
+      { head: "Divisions", items: match(divisionItems) },
+      { head: "Agents", items: match(agentItems) },
+    ].filter((g): g is { head: string; items: Item[] } => !!g && g.items.length > 0),
+  );
+
+  let selectedKey = $state("");
+  const allItems = $derived(groups.flatMap((g) => g.items));
+  // Keep a valid selection: default to the first item, and if filtering hides
+  // the current pick, fall back to the first visible one.
+  $effect(() => {
+    if (allItems.length > 0 && !allItems.some((i) => i.key === selectedKey)) {
+      selectedKey = allItems[0].key;
+    }
+  });
+  const selected = $derived(allItems.find((i) => i.key === selectedKey) ?? null);
+
+  // The selected set's agents that exist in the corpus.
+  const setAgents = $derived(
+    selected ? corpus.agents.filter((a) => selected.slugs.includes(a.slug)) : [],
+  );
+  const setTotal = $derived(setAgents.length);
+
+  // ── Right pane: per-tool installer, scoped to THIS project ──
+  const projectTools = $derived(
+    SUPPORTED_TOOLS.filter(
+      (t) =>
+        t.supportsProject &&
+        (install.tools.length === 0 ||
+          install.tools.some((ti) => ti.tool === t.id && ti.detected) ||
+          install.installed.some(
+            (r) => r.tool === t.id && r.state !== "removed" && (r.projectPath ?? null) === projectPath,
+          )),
+    ),
+  );
+
+  function cover(tool: Tool) {
+    const rows = install.installed.filter(
+      (r) =>
+        r.state !== "removed" &&
+        r.tool === tool &&
+        (r.projectPath ?? null) === projectPath &&
+        selected?.slugs.includes(r.slug),
+    );
+    const present = new Set(rows.map((r) => r.slug));
+    return {
+      rows,
+      count: present.size,
+      all: setTotal > 0 && present.size === setTotal,
+      some: present.size > 0 && present.size < setTotal,
+      hasForeign: rows.some((r) => r.state === "foreign"),
+    };
+  }
+
+  let busy = $state<Tool | null>(null);
+  let confirm = $state<{ tool: Tool; rows: InstalledAgent[] } | null>(null);
+
+  async function toggle(tool: Tool) {
+    if (busy || !selected) return;
+    const cov = cover(tool);
+    if (cov.all) {
+      if (cov.hasForeign) {
+        confirm = { tool, rows: cov.rows };
+        return;
+      }
+      await remove(tool, cov.rows);
+      return;
+    }
+    const present = new Set(cov.rows.map((r) => r.slug));
+    const missing = setAgents.filter((a) => !present.has(a.slug));
+    if (missing.length === 0) return;
+    busy = tool;
+    try {
+      const { ok, fail } = await install.bulk(
+        "install",
+        missing.map((a) => ({ slug: a.slug, tool, projectPath })),
+      );
+      if (fail === 0) toast.success(`Installed ${ok} → ${install.toolLabel(tool)} · ${projectName}`);
+      else toast.error(`${install.toolLabel(tool)}: ${ok} installed, ${fail} failed`);
+    } finally {
+      busy = null;
+    }
+  }
+
+  async function remove(tool: Tool, rows: InstalledAgent[]) {
+    busy = tool;
+    try {
+      const { ok, fail } = await install.bulk(
+        "uninstall",
+        rows.map((r) => ({ slug: r.slug, tool: r.tool, projectPath: r.projectPath })),
+      );
+      if (fail === 0) toast.success(`Removed ${ok} from ${install.toolLabel(tool)}`);
+      else toast.error(`${install.toolLabel(tool)}: ${ok} removed, ${fail} failed`);
+    } finally {
+      busy = null;
+    }
+  }
+
+  async function confirmRemove() {
+    if (!confirm) return;
+    const { tool, rows } = confirm;
+    confirm = null;
+    await remove(tool, rows);
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === "Escape" && !confirm) {
+      e.preventDefault();
+      onClose();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onKey} />
+
+<button class="scrim" aria-label="Close" onclick={onClose}></button>
+<div class="box" role="dialog" aria-modal="true" aria-label={`Deploy into ${projectName}`}>
+  <header class="head">
+    <div class="titles">
+      <h2 class="title">Deploy into {projectName}</h2>
+      <span class="sub" title={projectPath}>{projectPath}</span>
+    </div>
+    <button class="close" onclick={onClose} aria-label="Close"><X size={16} /></button>
+  </header>
+
+  <div class="panes">
+    <!-- LEFT: picker (agents · divisions · teams · current roster) -->
+    <nav class="list" aria-label="Choose what to deploy">
+      <div class="list-search">
+        <Input bind:value={query} variant="search" placeholder="Search agents, divisions, teams…" ariaLabel="Search what to deploy" />
+      </div>
+      <div class="list-scroll">
+        {#each groups as g (g.head)}
+          <h3 class="list-h">{g.head}</h3>
+          {#each g.items as it (it.key)}
+            <button class="li" class:on={selectedKey === it.key} onclick={() => (selectedKey = it.key)}>
+              <span class="li-ic" style={it.color ? `color:${it.color}` : ""}>
+                {#if it.emoji}{it.emoji}{:else if it.icon}{@const Icon = it.icon}<Icon size={16} />{/if}
+              </span>
+              <span class="li-body"><span class="li-label">{it.label}</span><span class="li-desc">{it.description}</span></span>
+            </button>
+          {/each}
+        {/each}
+        {#if groups.length === 0}
+          <p class="list-empty">No matches for “{query.trim()}”.</p>
+        {/if}
+      </div>
+    </nav>
+
+    <!-- RIGHT: detail + per-tool install for this project -->
+    <section class="detail">
+      {#if selected}
+        <div class="d-head">
+          <span class="d-ic" style={selected.color ? `color:${selected.color}` : ""}>
+            {#if selected.emoji}{selected.emoji}{:else if selected.icon}{@const SelIcon = selected.icon}<SelIcon size={20} />{/if}
+          </span>
+          <div class="d-titles">
+            <h3 class="d-name">{selected.label}</h3>
+            <p class="d-desc">{selected.description}</p>
+          </div>
+        </div>
+
+        <p class="d-section">Install into {projectName} —</p>
+        {#if projectTools.length === 0}
+          <p class="d-empty">No supported tools detected on this device.</p>
+        {:else}
+          <ul class="tools">
+            {#each projectTools as t (t.id)}
+              {@const cov = cover(t.id)}
+              {@const isBusy = busy === t.id}
+              <li class="tool">
+                <button
+                  class="t-toggle"
+                  class:on={cov.all}
+                  class:partial={cov.some}
+                  disabled={isBusy || setTotal === 0}
+                  aria-label={`${cov.all ? "Remove from" : "Install into"} ${t.label}`}
+                  onclick={() => toggle(t.id)}
+                >
+                  {#if isBusy}<span class="dot busy"></span>
+                  {:else if cov.all}<span class="dot full"></span>
+                  {:else if cov.some}<span class="dot half"></span>
+                  {:else}<span class="dot"></span>{/if}
+                </button>
+                <span class="t-label">{t.label}</span>
+                <span class="t-count">{#if cov.all}all {setTotal}{:else if cov.some}{cov.count}/{setTotal}{:else}none{/if}</span>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+
+        <p class="d-section">{setTotal} agent{setTotal === 1 ? "" : "s"}</p>
+        <ul class="agents">
+          {#each setAgents as a (a.slug)}
+            <li class="ag"><span class="ag-emoji">{a.emoji ?? "🧩"}</span>{a.name}</li>
+          {/each}
+        </ul>
+      {:else}
+        <p class="d-empty"><LayersIcon size={16} /> Pick something on the left to deploy.</p>
+      {/if}
+    </section>
+  </div>
+</div>
+
+{#if confirm}
+  {@const n = confirm.rows.length}
+  {@const label = install.toolLabel(confirm.tool)}
+  <DestructiveConfirm
+    open
+    title="Delete {n} file{n === 1 ? '' : 's'} from {label}?"
+    confirmLabel="Delete {n}"
+    onConfirm={confirmRemove}
+    onCancel={() => (confirm = null)}
+  >
+    <p>
+      This <strong>permanently removes {n} file{n === 1 ? "" : "s"} from disk</strong>,
+      <strong>including files installed outside this app</strong>. Any edits you made are backed up first.
+    </p>
+  </DestructiveConfirm>
+{/if}
+
+<style>
+  .scrim {
+    position: fixed; inset: 36px 0 0 0; z-index: 88;
+    background: color-mix(in srgb, var(--color-bg) 60%, transparent);
+    backdrop-filter: blur(4px); border: 0; cursor: default;
+  }
+  .box {
+    position: fixed; z-index: 89;
+    top: 64px; bottom: 64px; left: 50%; transform: translateX(-50%);
+    width: min(820px, 94vw);
+    display: flex; flex-direction: column;
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border); border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg); overflow: hidden;
+  }
+  .head { flex: none; display: flex; align-items: center; gap: var(--space-3); padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--color-border); }
+  .titles { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+  .title { font-size: var(--text-h2); font-weight: var(--fw-semibold); color: var(--color-text-primary); }
+  .sub { font-size: var(--text-caption); color: var(--color-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .close { flex: none; display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: var(--radius-md); color: var(--color-text-muted); cursor: pointer; }
+  .close:hover { background: var(--color-surface-sunken); color: var(--color-text-primary); }
+
+  .panes { flex: 1; min-height: 0; display: grid; grid-template-columns: 248px 1fr; }
+  .list { display: flex; flex-direction: column; min-height: 0; border-right: 1px solid var(--color-border); }
+  .list-search { flex: none; padding: var(--space-2); border-bottom: 1px solid var(--color-border); }
+  .list-scroll { flex: 1; min-height: 0; overflow-y: auto; padding: var(--space-2); }
+  .list-empty { padding: var(--space-3) var(--space-2); font-size: var(--text-body-sm); color: var(--color-text-muted); }
+  .list-h { font-size: var(--text-caption); font-weight: var(--fw-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.04em; padding: var(--space-2) var(--space-2) var(--space-1); }
+  .li { display: flex; align-items: center; gap: var(--space-2); width: 100%; padding: var(--space-2); border-radius: var(--radius-md); background: transparent; cursor: pointer; text-align: left; }
+  .li:hover { background: var(--color-surface-sunken); }
+  .li.on { background: var(--color-selection-strong); }
+  .li.on .li-label, .li.on .li-desc { color: var(--color-text-inverse); }
+  .li-ic { flex: none; display: inline-flex; align-items: center; justify-content: center; width: 18px; font-size: 14px; }
+  .li-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 0; }
+  .li-label { font-size: var(--text-body-sm); font-weight: var(--fw-medium); color: var(--color-text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .li-desc { font-size: var(--text-caption); color: var(--color-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  .detail { overflow-y: auto; padding: var(--space-4); }
+  .d-head { display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-3); }
+  .d-ic { flex: none; display: inline-flex; align-items: center; justify-content: center; width: 38px; height: 38px; border-radius: var(--radius-md); background: var(--color-surface-sunken); font-size: 20px; }
+  .d-titles { flex: 1; min-width: 0; }
+  .d-name { font-size: var(--text-h3); font-weight: var(--fw-semibold); color: var(--color-text-primary); }
+  .d-desc { font-size: var(--text-body-sm); color: var(--color-text-secondary); }
+  .d-section { font-size: var(--text-caption); font-weight: var(--fw-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.04em; margin: var(--space-3) 0 var(--space-1); }
+  .d-empty { display: flex; align-items: center; gap: 6px; font-size: var(--text-body-sm); color: var(--color-text-muted); }
+
+  .tools { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
+  .tool { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-2); border-radius: var(--radius-md); }
+  .tool:hover { background: var(--color-surface-sunken); }
+  .t-toggle { flex: none; display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; background: transparent; cursor: pointer; }
+  .t-toggle:disabled { cursor: default; }
+  .t-label { flex: 1; min-width: 0; font-size: var(--text-body); color: var(--color-text-primary); font-weight: var(--fw-medium); }
+  .t-count { font-size: var(--text-body-sm); color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
+  .dot { width: 16px; height: 16px; border-radius: 999px; border: 1.5px solid var(--color-border-strong, var(--color-text-muted)); box-sizing: border-box; }
+  .dot.full { background: var(--color-brand); border-color: var(--color-brand); }
+  .dot.half { border-color: var(--color-brand); background: linear-gradient(90deg, var(--color-brand) 50%, transparent 50%); }
+  .dot.busy { border-color: var(--color-text-muted); border-top-color: transparent; animation: spin 0.6s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  .agents { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; }
+  .ag { display: flex; align-items: center; gap: var(--space-2); padding: 3px var(--space-2); font-size: var(--text-body-sm); color: var(--color-text-secondary); }
+  .ag-emoji { flex: none; }
+</style>

--- a/src/lib/components/InstallModal.svelte
+++ b/src/lib/components/InstallModal.svelte
@@ -33,7 +33,11 @@
   }
   let { title, agentSlugs, onClose }: Props = $props();
 
-  onMount(() => projects.refresh());
+  onMount(() => {
+    projects.refresh();
+    // Refresh detection so the columns reflect tools ACTUALLY on this device.
+    void install.loadTools();
+  });
 
   // The agents in this set that exist in the corpus (stale slugs skipped).
   const slugSet = $derived(new Set(agentSlugs));
@@ -143,9 +147,13 @@
   }
 </script>
 
-<Modal open {title} onClose={onClose}>
+<Modal open {title} size="wide" onClose={onClose}>
   <p class="sub">{total} agent{total === 1 ? "" : "s"} · toggle a cell to install into that tool, globally or per project.</p>
 
+  {#if cols.length === 0}
+    <p class="no-tools">No supported tools detected on this device. Open <strong>Tools</strong> to check what's installed.</p>
+  {:else}
+  <div class="grid-wrap">
   <div class="grid" style="--cols: {cols.length}">
     <!-- header row -->
     <div class="cell head corner"></div>
@@ -187,6 +195,8 @@
       {/each}
     {/each}
   </div>
+  </div>
+  {/if}
 
   <button class="addrow" onclick={addProject}><FolderPlus size={14} /> Add project…</button>
 
@@ -215,16 +225,19 @@
 
 <style>
   .sub { font-size: var(--text-body-sm); color: var(--color-text-muted); margin-bottom: var(--space-3); }
+  .no-tools { font-size: var(--text-body-sm); color: var(--color-text-muted); }
 
+  /* Horizontal scroll guards against a very wide tool set (≫ the modal width). */
+  .grid-wrap { overflow-x: auto; border: 1px solid var(--color-border); border-radius: var(--radius-md); }
   .grid {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) repeat(var(--cols), 56px);
+    grid-template-columns: minmax(180px, 1fr) repeat(var(--cols), 68px);
+    width: max-content; min-width: 100%;
     align-items: stretch;
-    border: 1px solid var(--color-border); border-radius: var(--radius-md); overflow: hidden;
   }
   .cell { display: flex; align-items: center; justify-content: center; padding: var(--space-2); border-bottom: 1px solid var(--color-border); }
   .head { background: var(--color-surface-sunken); font-size: var(--text-caption); color: var(--color-text-muted); font-weight: var(--fw-semibold); min-height: 34px; }
-  .head.tool { writing-mode: horizontal-tb; text-align: center; padding: var(--space-2) 4px; line-height: 1.1; }
+  .head.tool { writing-mode: horizontal-tb; text-align: center; padding: var(--space-2) 8px; line-height: 1.15; }
   .corner { background: var(--color-surface-sunken); }
 
   .dest { justify-content: flex-start; gap: var(--space-2); min-width: 0; }

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -17,6 +17,8 @@
      *    for input-collection modals (e.g. "New Snapshot") so the field is focused first.
      */
     defaultFocus?: "cancel" | "confirm" | "first";
+    /** "default" caps width at 440px; "wide" allows a roomier modal (grids). */
+    size?: "default" | "wide";
     onClose?: () => void;
     children: Snippet;
     actions?: Snippet;
@@ -27,6 +29,7 @@
     title,
     dismissible = true,
     defaultFocus = "cancel",
+    size = "default",
     onClose,
     children,
     actions,
@@ -106,7 +109,7 @@
 {#if open}
   <div class="scrim" role="presentation" onclick={backdropClick}></div>
   <div class="modal-wrap" role="dialog" aria-modal="true" aria-labelledby="modal-title">
-    <div class="modal" bind:this={dialogEl}>
+    <div class="modal" class:wide={size === "wide"} bind:this={dialogEl}>
       <header>
         <h1 id="modal-title">{title}</h1>
         {#if dismissible}
@@ -146,6 +149,9 @@
     width: 100%;
     max-width: 440px;
     background: var(--color-surface-raised);
+  }
+  .modal.wide { max-width: min(760px, 94vw); }
+  .modal {
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-modal);

--- a/src/lib/components/Projects.svelte
+++ b/src/lib/components/Projects.svelte
@@ -28,8 +28,7 @@
   import EmptyState from "./EmptyState.svelte";
   import Pill from "./Pill.svelte";
   import Button from "./Button.svelte";
-  import Modal from "./Modal.svelte";
-  import InstallModal from "./InstallModal.svelte";
+  import DeployBrowser from "./DeployBrowser.svelte";
   import FolderIcon from "@lucide/svelte/icons/folder";
   import FolderPlus from "@lucide/svelte/icons/folder-plus";
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
@@ -37,10 +36,7 @@
   import Trash2 from "@lucide/svelte/icons/trash-2";
 
   import { install } from "$lib/stores/install.svelte";
-  import { corpus } from "$lib/stores/corpus.svelte";
   import { projects } from "$lib/stores/projects.svelte";
-  import { PRESET_TEAMS } from "$lib/data/presetTeams";
-  import { resolveCategoryIcon } from "$lib/util/categoryIcon";
   import type { InstalledAgent, ProjectInfo } from "$lib/types";
 
   onMount(() => {
@@ -66,10 +62,6 @@
   function rosterFor(path: string): InstalledAgent[] {
     return rowsByProject.get(path) ?? [];
   }
-  // Distinct agent slugs deployed into a project — the SET we seed Deploy… with.
-  function slugsFor(path: string): string[] {
-    return [...new Set(rosterFor(path).map((r) => r.slug))];
-  }
 
   // ── Expand / collapse a project's roster (mirrors Teams' division groups). ──
   let expanded = $state<Set<string>>(new Set());
@@ -80,45 +72,11 @@
     expanded = next;
   }
 
-  function basename(path: string): string {
-    return path.replace(/\/+$/, "").split("/").pop() || path;
-  }
+  // ── Deploy into a project: open the two-pane DeployBrowser (pick an agent,
+  // division, or team on the left; install into this project's tools on the
+  // right). Opening it on a freshly-added project lets an empty one be filled. ──
+  let browseFor = $state<string | null>(null); // project path, or null = closed
 
-  // ── Two-step deploy: first CHOOSE what to put in the project (a division, a
-  // preset, or "manage the current roster"), then the DeployModal tri-states it
-  // across that project's tools. Choosing-first is what lets an EMPTY project be
-  // populated — seeding the modal with [] would make it inert. ──
-  let chooserFor = $state<string | null>(null); // project path, or null = closed
-
-  // Division choices: every division that actually has agents in the corpus.
-  const divisionChoices = $derived(
-    corpus.tiles.map((c) => ({
-      key: `div:${c.slug}`,
-      label: c.label,
-      icon: resolveCategoryIcon(c.icon),
-      color: corpus.colorOf(c.slug),
-      slugs: corpus.agents.filter((a) => a.category === c.slug).map((a) => a.slug),
-    })),
-  );
-
-  // DeployModal target (the project) + the chosen set.
-  let deployTarget = $state<string | undefined>(undefined);
-  let deploySlugs = $state<string[]>([]);
-  let deployTitle = $state("");
-  const showDeploy = $derived(deployTarget !== undefined);
-
-  function deploySet(path: string, slugs: string[], what: string) {
-    chooserFor = null;
-    deployTarget = path;
-    deploySlugs = slugs;
-    deployTitle = `${what} → ${basename(path)}`;
-  }
-  function closeDeploy() {
-    deployTarget = undefined;
-    deploySlugs = [];
-  }
-
-  // ── Add a project → register + show the chooser so it can be populated. ──
   let adding = $state(false);
   async function addProject() {
     if (adding) return;
@@ -127,7 +85,7 @@
       const p = await projects.addViaPicker();
       if (!p) return;
       await projects.refresh();
-      chooserFor = p;
+      browseFor = p;
     } finally {
       adding = false;
     }
@@ -186,7 +144,7 @@
               </span>
             </button>
             <span class="proj-count">{project.installedCount} agent{project.installedCount === 1 ? "" : "s"}</span>
-            <Button size="sm" variant="secondary" onclick={() => (chooserFor = project.path)}>Deploy…</Button>
+            <Button size="sm" variant="secondary" onclick={() => (browseFor = project.path)}>Deploy…</Button>
             <button class="proj-del" title="Remove from list" aria-label="Remove project from list" onclick={() => projects.unregister(project.path)}><Trash2 size={14} /></button>
           </div>
 
@@ -211,45 +169,8 @@
   {/if}
 </section>
 
-{#if chooserFor !== null}
-  {@const path = chooserFor}
-  {@const current = slugsFor(path)}
-  <Modal open title="Deploy into {basename(path)}" onClose={() => (chooserFor = null)}>
-    <p class="ch-sub">Pick a team or division to deploy into this project — then choose its tools.</p>
-
-    {#if current.length > 0}
-      <button class="ch-row" onclick={() => deploySet(path, current, "Current roster")}>
-        <span class="ch-ic"><FolderIcon size={16} /></span>
-        <span class="ch-body"><span class="ch-label">Current roster</span><span class="ch-meta">{current.length} agent{current.length === 1 ? "" : "s"} already here — add/remove across tools</span></span>
-      </button>
-    {/if}
-
-    <p class="ch-h">Presets</p>
-    {#each PRESET_TEAMS as p (p.slug)}
-      {@const PIcon = p.icon}
-      <button class="ch-row" onclick={() => deploySet(path, p.agents, p.label)}>
-        <span class="ch-ic" style="color:{p.color}"><PIcon size={16} /></span>
-        <span class="ch-body"><span class="ch-label">{p.label}</span><span class="ch-meta">{p.description}</span></span>
-      </button>
-    {/each}
-
-    <p class="ch-h">Divisions</p>
-    {#each divisionChoices as d (d.key)}
-      {@const DIcon = d.icon}
-      <button class="ch-row" onclick={() => deploySet(path, d.slugs, d.label)}>
-        <span class="ch-ic" style="color:{d.color}"><DIcon size={16} /></span>
-        <span class="ch-body"><span class="ch-label">{d.label}</span><span class="ch-meta">{d.slugs.length} agent{d.slugs.length === 1 ? "" : "s"}</span></span>
-      </button>
-    {/each}
-
-    {#snippet actions()}
-      <Button variant="secondary" onclick={() => (chooserFor = null)}>Cancel</Button>
-    {/snippet}
-  </Modal>
-{/if}
-
-{#if showDeploy && deployTarget !== undefined}
-  <InstallModal title={deployTitle} agentSlugs={deploySlugs} onClose={closeDeploy} />
+{#if browseFor !== null}
+  <DeployBrowser projectPath={browseFor} onClose={() => (browseFor = null)} />
 {/if}
 
 <style>
@@ -296,14 +217,6 @@
   .proj-del:hover { background: var(--color-surface-sunken); color: var(--color-danger); }
 
   /* ── Deploy chooser (pick a team/division to put into the project) ── */
-  .ch-sub { font-size: var(--text-body-sm); color: var(--color-text-secondary); margin-bottom: var(--space-3); }
-  .ch-h { font-size: var(--text-caption); font-weight: var(--fw-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.04em; margin: var(--space-3) 0 var(--space-1); }
-  .ch-row { display: flex; align-items: center; gap: var(--space-3); width: 100%; padding: var(--space-2); border-radius: var(--radius-md); background: transparent; cursor: pointer; text-align: left; }
-  .ch-row:hover { background: var(--color-surface-sunken); }
-  .ch-ic { flex: none; display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border-radius: var(--radius-md); background: var(--color-surface-sunken); }
-  .ch-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
-  .ch-label { font-weight: var(--fw-medium); color: var(--color-text-primary); }
-  .ch-meta { font-size: var(--text-caption); color: var(--color-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   .roster { list-style: none; margin: 0; padding: 0 var(--space-3) var(--space-2) calc(15px + var(--space-2) + var(--space-3)); display: flex; flex-direction: column; gap: 1px; }
   .r-row { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-2) var(--space-3); border-radius: var(--radius-md); }


### PR DESCRIPTION
Builds on the Projects pillar with a much better deploy experience + a modal-width fix.

## Two-pane Deploy browser (`DeployBrowser.svelte`)
The Projects **Deploy…** button now opens a System-Settings-style master/detail picker instead of the old flat, mile-long chooser:
- **Left** — a searchable list of **every deployable granularity**: individual **agents**, **divisions**, **teams** (presets **+** your saved teams), and the project's **current roster**.
- **Right** — the selected item's agents + a **per-tool installer scoped to that project** (tri-state all/some/none; foreign-aware delete).

## Wide install modal
The destinations × tools grid clipped the last column (`opencode`) once there were >3 tools. Fixes:
- `Modal` gains a **`size="wide"`** (~760px); `InstallModal` uses it.
- Tool columns widened + header padding so labels breathe; horizontal-scroll guard for very wide tool sets.
- Grid shows **only detected tools** (refreshes detection on open).

## Memory bank
`memory-bank/activeContext.md` refreshed to the current v0.1.1 state (the whole IA arc shipped) + backlog.

## Backlog captured (not in this PR)
- InstallModal should pick from existing Projects + a "New Project…" option (instead of an inline folder-picker).
- "Auto Updates" subscription for bulk installs.
- Copilot `.agent.md`; optionally stricter backend `detect()`.

## Verification
`npm run check`: 0 errors. Exercised in the browser harness (two-pane browser, tri-state per-project install, wide 7-column grid). No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)