### PR TITLE
docs(memory-bank): record the v0.1.2 tool-registry + Osaurus arc

### DIFF
--- a/memory-bank/NEXT-SESSION.md
+++ b/memory-bank/NEXT-SESSION.md
@@ -3,6 +3,15 @@
 Read this first after a compaction. Then `activeContext.md`, `agentLog.md` (append-only history),
 `phases/phase-roadmap.md`, `contracts.md`, `systemPatterns.md`, `decisions.md`.
 
+## ⏩ CURRENT (2026-06-22) — read `activeContext.md` for the live picture
+v0.1.0 SHIPPED (2026-06-16, public/signed/brew). Since then: **v0.1.1** (IA re-org — divisions landing, Teams,
+Projects pillar, the single InstallModal grid + DeployBrowser) and **v0.1.2** (`main` @ `1df932c`, PRs #18+#19):
+the **tool registry single-source** arc — `Tool` enum gone, one upstream-owned `tools.json` (twin of
+`divisions.json`), installability derived from `format ∈ IMPLEMENTED_FORMATS`, all 13 tools, **Osaurus wired**
+(`skill-md`), in-app Playbook, Teams/Projects master-detail, Projects dashboard sunburst. Much below predates
+v0.1.0 (counts/paths may be stale) — `activeContext.md` + `agentLog.md` are authoritative. **NEXT: release prep
+for v0.1.2** (version bump + notes + README Loadouts→Teams).
+
 ## ✅ THE RE-ORG LANDED (verified 2026-06-14)
 The catalog re-org happened: the active clone now indexes **232 agents** (was ~222). The parity test
 runs against this live clone and passes 1160/1160, so category discovery + recursive indexing absorbed

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,9 +6,34 @@
 Site: [agencyagents.app](https://agencyagents.app). Homebrew: `brew tap msitarzewski/agency-agents && brew install --cask agency-agents`.
 Cross-platform CI in `.github/workflows/` (linux-build, windows-build) fires on `v*` tags. macOS DMGs build
 locally via `scripts/release.sh` (mind the beta-toolchain `MACOSX_DEPLOYMENT_TARGET` gotcha — `docs/BUILD.md`).
-Now on **v0.1.1 dev**. Full launch log: `agentLog.md` 2026-06-16.
+Now on **v0.1.2 dev** (`main` @ `1df932c`, PRs #18 + #19 merged). Full launch log: `agentLog.md` 2026-06-16.
 
 **Workflow (from 2026-06-16):** ALL changes go through a **branch → PR → merge to `main`**. No direct commits to main.
+
+## ✅ v0.1.2 — Tool registry + Osaurus + Playbook + Projects dashboard — SHIPPED (2026-06-21, PRs #18 + #19; `main` @ 1df932c)
+**Tool knowledge is now a single source of truth.** It consolidated to the single canonical `tools.json` the
+upstream `agency-agents` repo OWNS (twin of `divisions.json`, CI-guarded by its no-jq `check-tools.sh`); both the
+Rust backend (`registry.rs`, `include_str!`) and the frontend (`toolRegistry.ts`) read it. **The Rust `Tool` enum
+is GONE** — a tool is a string id; `label`/`detect`/`version`/`dests`/`scope` are registry lookups; `render()`
+dispatches on the JSON `format` key. Frontend deleted ACCENTS/ICONS_SVG/SHORT/hardcoded SUPPORTED_TOOLS.
+**Adding a tool = editing one JSON file** (+ a Rust formatter only for a brand-new output format).
+- **All 13 tools** modeled (incl. Kimi, Osaurus); Tools panel shows installable + recognized-only (dimmed). Real
+  brand logos (Lobe Icons, MIT) under `assets/tools/`, letter fallback otherwise.
+- **Installability derived, not stored:** `installable(tool) = format ∈ IMPLEMENTED_FORMATS` ({identity,
+  codex-toml, gemini-md, qwen-md, cursor-mdc, opencode-md, skill-md}). aa owns upstream truth; renderer coverage
+  is app-side + self-maintaining (ship a renderer → add its format → those tools light up).
+- **Osaurus wired** via a `skill-md` format (Agent-Skills `SKILL.md`, `slugPrefix:"agency-"`), byte-identical to
+  upstream `convert_osaurus` — contributed UPSTREAM first (catalog owns transforms), mirrored here (parity test).
+  Verified live: catalog agents run as native Osaurus skills.
+- **Playbook** (in-app practices + copyable starter prompts + per-team/division examples; title-bar 📖 + ⌘K) +
+  `docs/USING-AGENTS.md`. **Teams & Projects master/detail** via the system back arrow
+  (`ui.projectsSelected`/`teamsSelected`); **division overview** + deploy.
+- **Dashboard**: two-ring Global-vs-Projects install **sunburst** (`InstallSunburst.svelte`) so totals reconcile;
+  cross-tool coverage **merged** with catalog-by-division (linked hover); uniform donuts, equal-height cards.
+
+Task doc: [tasks/2026-06/260621_tool-registry-12-tools-osaurus.md](tasks/2026-06/260621_tool-registry-12-tools-osaurus.md).
+Green: cargo 264/0, svelte-check 0, build clean. Upstream `agency-agents` (same machine): Osaurus transformer +
+`tools.json` + `check-tools.sh` + `check-tools.yml` landed (aa PRs #605/#606).
 
 ## ✅ v0.1.1 IA arc — SHIPPED (2026-06-17 → 06-20, PRs #15 + #16, + the deploy-browser PR)
 The whole "how people think about agents" reorganization landed:
@@ -32,8 +57,13 @@ The whole "how people think about agents" reorganization landed:
 **Four-pillar model (drives IA copy):** Agents = *who* · Tools = *how* · Teams = *which* · Projects = *where*.
 
 ## 🔵 Backlog (next)
-- **InstallModal → pick from existing Projects + "New Project…"** (instead of the inline folder-picker; now
-  that Projects is a managed list). [raised 2026-06-20]
+- **Release prep** for v0.1.2: version bump + release notes + README features pass ("Loadouts" → Teams; mention
+  the tool registry / 13 tools / Osaurus).
+- **Refresh `tools.json` from the catalog clone** (vs. the bundled baseline) — like the corpus + `divisions.json`;
+  cleaner now that aa #605 prunes stale convert output.
+- **Foreign-sweep for nested skill dirs** (`…/<dir>/SKILL.md`) so CLI-installed Osaurus/Antigravity skills are
+  detected (app-installed ones already are).
+- **Antigravity wiring** once upstream makes its skill deterministic (drops the non-deterministic `date_added`).
 - **"Auto Updates" subscription** for bulk installs — installing all of a division/team into a project/tool
   offers to auto-deploy newly-added catalog agents.
 - **Copilot `.md` → `.agent.md`** (needs reconcile `file_stem` double-extension handling).
@@ -45,7 +75,7 @@ auto-driven), a `?shim=1` Tauri-IPC shim is temporarily injected into `src/app.h
 ships. The shim can't open a real native folder dialog (returns a fixture path), so "Add project…" looks broken
 in the shim though it works natively.
 
-**Last updated**: 2026-06-20
+**Last updated**: 2026-06-22
 
 ## ✅ Pre-release polish (2026-06-15) — committed + pushed on `release-planning`
 - **brew vestige cleanup**: error-type rename (`BrewError*`→`AppError*`), removed dead `catalogAutoRefresh`

--- a/memory-bank/agentLog.md
+++ b/memory-bank/agentLog.md
@@ -648,3 +648,24 @@ Cut the first public release: **github.com/msitarzewski/agency-agents-app/releas
   fingerprints don't include it), then Tauri reuses the cache to bundle. Full recipe in `docs/BUILD.md`
   ("Troubleshooting: proc-macro 'can't find crate' on a beta macOS") + [[macos-beta-macosx-deployment-target-breaks-proc-macros]].
   Red herrings ruled out: toolchain, linker, Xcode CLT-vs-beta, PATH/node shims, ulimit (1M), disk (5TB), RAM (128GB).
+
+## 2026-06-21 — v0.1.2: tool registry single-source + all 13 tools + Osaurus + Playbook + Projects dashboard
+Two PRs merged (`main` @ `1df932c`):
+- **PR #18** — Tool registry as the single source of truth. Killed the Rust `Tool` enum (a tool is now a string
+  id; label/detect/version/dests/scope are registry lookups, `render()` dispatches on a `format` key); deleted
+  the frontend ACCENTS/ICONS_SVG/SHORT/hardcoded SUPPORTED_TOOLS. All 13 tools modeled (incl. Kimi), real brand
+  logos (Lobe Icons, MIT). **Osaurus wired** via a new `skill-md` format (Agent-Skills `SKILL.md`, byte-identical
+  to upstream `convert_osaurus`) — verified live, catalog agents run as native Osaurus skills. Plus the Playbook
+  (in-app + `docs/USING-AGENTS.md`), Teams/Projects master-detail (system back-arrow nav), division overview, and
+  a Global-vs-Projects dashboard sunburst + merged cross-tool/catalog card. 8 themed commits.
+- **PR #19** — consolidated to the single upstream-owned `tools.json`; dropped the `wired` field + `include_dir`
+  dep; **installability derived** from `format ∈ IMPLEMENTED_FORMATS` (7 formats) on both sides.
+- **Upstream coordination** (`AgentLand/agency-agents`, same machine, with the "aa Claude"): contributed the
+  Osaurus transformer (`convert.sh`/`install.sh`) and the canonical `tools.json` + `scripts/check-tools.sh`
+  (no-jq twin of `check-divisions.sh`) + `.github/workflows/check-tools.yml`. aa landed PRs #605/#606; our
+  bundled `tools.json` is byte-identical to the canonical (diff-verified — same machine, no relaying).
+- Green: `cargo test` 264/0 (parity intact), `svelte-check` 0, build clean. Cargo.toml `macos-private-api`
+  injection reverted before each commit (the usual `tauri dev` cycle).
+- Decisions recorded in `decisions.md` (registry single-source / Tool=string · `tools.json` upstream-owned +
+  derived installability · contribute transforms upstream first). Task doc:
+  `tasks/2026-06/260621_tool-registry-12-tools-osaurus.md`.

--- a/memory-bank/decisions.md
+++ b/memory-bank/decisions.md
@@ -141,3 +141,38 @@ wiring when we do it: a `tauri.windows.conf.json` (mirroring the macOS split) wi
 `bundle.windows.certificateThumbprint`/`signCommand` + `timestampUrl`, build the **NSIS** installer (drop
 `--no-bundle`), sign exe + installer for both arm64 and x64, and verify on the Parallels Windows 11 VM with
 a Mark-of-the-Web download.
+
+### 2026-06-21: Tool registry as the single source of truth (drop the `Tool` enum)
+**Status**: Approved (PRs #18 + #19). **Context**: tool knowledge was scattered — a Rust `Tool` enum + 8
+hardcoded match-arm functions (label/detect/version/dests/scope/render), and on the frontend `ACCENTS`/
+`ICONS_SVG`/`SHORT`/a hardcoded `SUPPORTED_TOOLS` + a `Tool` union. Adding a tool meant editing ~13 places;
+adding one upstream in the CLI meant another ~13. **Decision**: a JSON registry is the single source. The Rust
+`Tool` enum is removed — a tool is a `String` id; `label`/`detect`/`version`/`dests`/`scope` are registry lookups
+and `render()` dispatches on a `format` key. The string id IS the serialized wire value (camelCase), so ledger
+JSON stays compatible. **Alternatives**: codegen a typed union from the JSON (rejected — a generate step is "an
+index to forget," the exact thing we're killing). **Consequences**: adding a tool that reuses an existing
+`format` is data-only on both sides; a brand-new output shape needs one formatter function. Byte-parity tests
+guard the render output. Load-bearing.
+
+### 2026-06-21: `tools.json` is upstream-owned; installability is derived app-side
+**Status**: Approved (coordinated with the `agency-agents` catalog repo). **Context**: who owns the canonical
+tool list? The catalog repo already owns `divisions.json` (validated by a no-jq `check-divisions.sh`), and the
+app is "a respectful frontend over the clone." **Decision**: the catalog repo owns the canonical **`tools.json`**
+(twin of `divisions.json`), CI-guarded by `check-tools.sh` (the no-jq twin of `check-divisions.sh`, enforced by
+`check-tools.yml`). It carries *upstream truth only* — what the CLI converts + installs. The app consumes a
+bundled baseline (follow-up: refresh from the clone). Whether THIS app can install a tool is **derived, not
+stored**: `installable(tool) = tool.format ∈ IMPLEMENTED_FORMATS` (the 7 formats the Rust renderer implements).
+**Alternatives**: an `appRenderer`/`wired` bool in the catalog (rejected — couples upstream to app release
+state; the format-membership rule is self-maintaining: ship a renderer → add its format → those tools light up).
+**Consequences**: the catalog stays app-agnostic; the app's renderer coverage is one constant in two places
+(`registry.rs` + `toolRegistry.ts`); the two repos share one CI-protected contract.
+
+### 2026-06-21: Contribute transforms UPSTREAM first (Osaurus / the `skill-md` format)
+**Status**: Approved. **Context**: the Rust `render/` is a byte-identical *port* of the catalog's
+`scripts/convert.sh` (guarded by the parity test). A transform the app invents but `convert.sh` lacks would
+**diverge** — a CLI `install.sh` user wouldn't get it. **Decision**: new transforms land in the catalog's
+`convert.sh`/`install.sh` FIRST (canonical), then the app mirrors them. Osaurus shipped this way: a
+`convert_osaurus` → Agent-Skills `SKILL.md` upstream, mirrored by a Rust `skill-md` format (with `slugPrefix:
+"agency-"`). **Consequences**: one `skill-md` renderer covers Osaurus and any future Agent-Skills tool; the
+parity test keeps the app honest. Antigravity stays app-recognized-only until upstream makes its skill
+deterministic (its `date_added` is non-deterministic, so it can't share `skill-md`).

--- a/memory-bank/tasks/2026-06/260621_tool-registry-12-tools-osaurus.md
+++ b/memory-bank/tasks/2026-06/260621_tool-registry-12-tools-osaurus.md
@@ -1,0 +1,74 @@
+# 260621_tool-registry-12-tools-osaurus
+
+## Objective
+Make tool knowledge a single source of truth (vs. scattered across Rust match arms +
+frontend maps), surface all recognized tools, wire Osaurus end-to-end, and add the
+in-app Playbook + Teams/Projects detail + a Projects-aware dashboard. Then consolidate
+to the upstream-owned canonical `tools.json` so the app and the `agency-agents` CLI
+share one contract.
+
+## Outcome
+- ✅ `cargo test` 264/0 (byte-parity render tests intact), `svelte-check` 0, build clean.
+- ✅ Merged: **PR #18** (registry arc) + **PR #19** (single `tools.json`). `main` @ `1df932c`.
+- ✅ Upstream `agency-agents` (same machine, `AgentLand/`): Osaurus transformer + `tools.json`
+  + `check-tools.sh` + `check-tools.yml` landed (aa-side PRs #605/#606; `check-tools.yml` staged).
+
+## What shipped
+### Tool registry = single source of truth
+- `src-tauri/data/tools.json` (bundled baseline of the upstream canonical) + `registry.rs`
+  load it; the frontend `toolRegistry.ts` reads the same file. **The Rust `Tool` enum is gone** —
+  a tool is a `String` id; `label`/`detect`/`version`/`dests`/`scope` are registry lookups and
+  `render()` dispatches on the JSON `format` key. Frontend deleted `ACCENTS`/`ICONS_SVG`/`SHORT`/
+  the hardcoded `SUPPORTED_TOOLS`. **Adding a tool = editing one JSON file** (+ a Rust formatter
+  only for a brand-new output format).
+- **All 12→13 tools** modeled (incl. Kimi, Osaurus); Tools panel lists installable + recognized-only
+  (dimmed, "not yet installable"). Real **brand logos** vendored from Lobe Icons (MIT) under
+  `src/lib/assets/tools/`, tinted on the accent tile; letter fallback for the iconless.
+
+### Osaurus (the payoff)
+- New `skill-md` render format = the Anthropic Agent-Skills `SKILL.md` (frontmatter `name`+`description`
+  + persona body), byte-identical to the upstream `convert_osaurus`. `slugPrefix:"agency-"` namespaces
+  the skill dir + `name`. Verified live: catalog agents run as native Osaurus skills.
+- The transformer was contributed UPSTREAM first (`scripts/convert.sh` `convert_osaurus` + `install.sh`),
+  per the "the catalog repo owns transforms" layering; our Rust render mirrors it (parity test).
+
+### Installability is derived, not stored
+- `tools.json` carries upstream truth only. Whether THIS app can install a tool is
+  `installable(tool) = tool.format ∈ IMPLEMENTED_FORMATS` ({identity, codex-toml, gemini-md, qwen-md,
+  cursor-mdc, opencode-md, skill-md}) — same 8-installable / 5-recognized split, self-maintaining
+  (ship a renderer → add its format → those tools light up). No catalog flag to sync.
+
+### IA additions
+- **Playbook** — in-app practices + copyable starter prompts + per-team/division examples
+  (`playbook.ts`, `StarterPrompt.svelte`, `PlaybookModal.svelte`, title-bar book icon, ⌘K) + `docs/USING-AGENTS.md`.
+- **Teams & Projects master/detail** driven by the system back arrow (`ui.projectsSelected`/`teamsSelected`);
+  division-grouped rosters; **division overview** + deploy.
+- **Dashboard** — two-ring Global-vs-Projects install **sunburst** (`InstallSunburst.svelte`) so totals
+  reconcile; cross-tool coverage **merged** with catalog-by-division into one card with linked hover;
+  uniform donut sizing; equal-height cards.
+
+## Decisions (see decisions.md)
+- Tool registry as single source of truth; `Tool` = string id; render dispatch on `format`.
+- `tools.json` is **upstream-owned** (catalog repo, like `divisions.json`), CI-guarded by `check-tools.sh`;
+  the app consumes a bundled baseline (follow-up: refresh from the clone).
+- Installability derived app-side from `format`, not stored in the catalog.
+
+## Files
+- Backend: `registry.rs` (NEW), `render/mod.rs`, `install/mod.rs`, `types.rs` (Tool=String), `lib.rs`,
+  `Cargo.toml` (`include_dir` added then removed), `data/tools.json` (NEW; replaced `data/tools/*.json`).
+- Frontend: `data/{toolRegistry,playbook}.ts` (NEW), `components/{StarterPrompt,PlaybookModal,InstallSunburst}.svelte`
+  (NEW), `util/toolBadge.ts` (slim re-export), `components/{ToolsView,Teams,Projects,AgentsWorkspace,
+  InstallModal,DeployBrowser,CoverageDonuts,CatalogByDivision,AgencyDashboard,CommandPalette,TitlebarControls}.svelte`,
+  `stores/{ui,install}.svelte.ts`, `types.ts` (Tool=string), `routes/+page.svelte`, `assets/tools/*.svg` (NEW).
+- Docs: `docs/USING-AGENTS.md` (NEW), `README.md`.
+- Upstream (`AgentLand/agency-agents`): `scripts/{convert,install}.sh`, `tools.json`, `scripts/check-tools.sh`,
+  `.github/workflows/check-tools.yml`.
+
+## Artifacts
+- PRs: #18, #19 (this repo). aa: #605, #606 (+ staged `check-tools.yml`).
+
+## Deferred
+- Refresh `tools.json` from the catalog clone (vs. bundling a copy) — cleaner after aa #605 prunes stale output.
+- Foreign-sweep for nested `…/<dir>/SKILL.md` skills (CLI-installed Osaurus/Antigravity not auto-detected).
+- Antigravity wiring once upstream makes its skill deterministic (drops `date_added`).
+- Release prep: version bump + release notes + README "Loadouts" → Teams.

--- a/memory-bank/tasks/2026-06/README.md
+++ b/memory-bank/tasks/2026-06/README.md
@@ -44,7 +44,24 @@ inherited "Activity" surface into a **usage journal** (workflow-built + team-rev
 (`.cargo/config.toml`). Green: svelte-check 0, cargo 258/0. Pushed on `release-planning` (not cut).
 See [260615_pre-release-polish.md](./260615_pre-release-polish.md).
 
+### 2026-06-16: v0.1.0 SHIPPED — public, signed, Homebrew
+First public release: 7 cross-platform artifacts (signed/notarized macOS DMGs, Linux deb/rpm/AppImage, Windows
+NSIS), repo made public, `brew tap msitarzewski/agency-agents`. See agentLog 2026-06-16.
+
+### 2026-06-17→20: v0.1.1 — the IA re-org (PRs #15 + #16 + deploy-browser)
+Divisions landing, install-state lens, Teams (← Loadouts), the how×where engine, Projects pillar, the single
+destinations×tools InstallModal, the two-pane DeployBrowser. Four-pillar model (Agents/Tools/Teams/Projects =
+who/how/which/where). See activeContext.md.
+
+### 2026-06-21: v0.1.2 — tool registry + all 13 tools + Osaurus + Playbook + Projects dashboard (PRs #18 + #19)
+Made tool knowledge a single source of truth (upstream-owned `tools.json`, twin of `divisions.json`; Rust `Tool`
+enum dropped; installability derived from `format ∈ IMPLEMENTED_FORMATS`). All 13 tools + real brand logos;
+**Osaurus wired** via a `skill-md` format byte-identical to the upstream transformer (contributed upstream first).
+In-app Playbook + `docs/USING-AGENTS.md`; Teams/Projects master-detail; Global-vs-Projects dashboard sunburst.
+cargo 264/0, svelte-check 0. See [260621_tool-registry-12-tools-osaurus.md](./260621_tool-registry-12-tools-osaurus.md).
+
 ## Next
-- Phase 4 — Trending + GitHub.
-- Deferred: multi-file tool renderers (antigravity/openclaw/aider/windsurf); local-runtime system-prompt
-  target (Ollama/LM Studio).
+- **Release prep** for v0.1.2: version bump + release notes + README "Loadouts" → Teams.
+- Refresh `tools.json` from the catalog clone; Foreign-sweep for nested skill dirs; Antigravity once its skill is
+  deterministic (`date_added` dropped).
+- Deferred: local-runtime system-prompt target (Ollama/LM Studio).


### PR DESCRIPTION
Memory-bank update for the v0.1.2 arc (PRs #18 + #19, `main` @ `1df932c`). Docs only.

- **activeContext.md** — new v0.1.2 section (tool registry single-source, all 13 tools, Osaurus via `skill-md`, Playbook, Teams/Projects master-detail, Projects dashboard sunburst); state bumped to v0.1.2 dev; backlog refreshed (release prep · refresh tools.json from clone · Foreign-sweep nested skills · Antigravity).
- **tasks/2026-06/** — new task doc `260621_tool-registry-12-tools-osaurus.md` + README entries (v0.1.0 / v0.1.1 / v0.1.2) and updated Next.
- **decisions.md** — 3 ADRs: registry single-source / drop the `Tool` enum · `tools.json` upstream-owned + installability derived from `format` · contribute transforms upstream first (Osaurus / `skill-md`).
- **agentLog.md** — appended the 2026-06-21 session entry.
- **NEXT-SESSION.md** — current-state pointer atop the (older) resume notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)