### PR TITLE
Release v0.2.0 — four-pillar IA, tool registry, Osaurus, Playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,16 @@ The core idea is simple: AI tools do not share a package database, so the app ke
 
 ## Features
 
-- **Agents workspace** — searchable three-pane catalog, category filters, detail panel, and per-agent deployment controls.
+Agency Agents is organized around four pillars — **Agents** (who), **Tools** (how), **Teams** (which), and **Projects** (where):
+
+- **Agents workspace** — searchable three-pane catalog, division and category filters, an install-state lens, a detail panel, and per-agent deployment controls.
+- **Tools panel** — shows all recognized tools from the registry, detected installs, counts, versions where available, default targets, project installs, and bulk operations. Installable targets render in full; recognized-only targets appear dimmed.
+- **Teams** — app-bundled preset teams plus your own saved teams; open a team for a detail panel with Deploy built in. (Teams replaces the earlier "Loadouts" concept; Agentfile export/import remains.)
+- **Projects** — project-scoped installs with a dedicated panel and master/detail navigation, so a project gets exactly the agents and tools it needs.
 - **Install tracking** — records every app-managed install with source hash, rendered hash, tool, destination, scope, and project path where relevant.
 - **Reconciliation** — classifies installed files as current, outdated, modified, removed, or foreign by re-rendering canonical source and comparing bytes.
-- **Tools panel** — shows detected tools, installed counts, versions where available, default targets, project installs, and bulk operations.
-- **Dashboard** — coverage, health, category distribution, and category-by-tool charts with deep links back into the workspace.
-- **Loadouts** — save and restore groups of agents as portable Agentfiles.
+- **Tool registry** — tool knowledge lives in a single upstream-owned `tools.json` shared by the backend and frontend; adding a tool is editing one JSON entry, and installability is derived from whether the app ships a renderer for that tool's format.
+- **Dashboard** — install health, a Global-vs-Projects install sunburst, cross-tool coverage merged with the catalog-by-division view (linked hover), and deep links back into the workspace.
 - **GitHub integration** — optional OAuth Device Flow for GitHub-backed app features. Tokens are stored in the platform keychain and are never returned to the frontend.
 - **Offline-first catalog** — ships with a bundled corpus baseline and can use a local or managed clone of `agency-agents`.
 - **Cross-platform shell** — Tauri 2 + Svelte 5 frontend with native macOS chrome and opaque native windows on Windows/Linux.
@@ -58,8 +62,9 @@ The app currently installs to the renderer-backed targets that have deterministi
 | Qwen Code | user | `~/.qwen/agents/*.md` |
 | Cursor | project | `.cursor/rules/*.mdc` |
 | opencode | project | `.opencode/agents/*.md` |
+| Osaurus | user | `~/.osaurus/skills/agency-<slug>/SKILL.md` |
 
-The upstream AA repo also contains integrations for Antigravity, Aider, Windsurf, OpenClaw, and Kimi. Those output shapes need additional app work before they should be exposed as first-class app installs.
+The upstream AA repo also contains integrations for Antigravity, Aider, Windsurf, OpenClaw, and Kimi. Those output shapes need additional app work before they should be exposed as first-class app installs — they appear in the Tools panel as recognized-only.
 
 ## What This Isn't
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -141,7 +141,7 @@ The ordered runbook for cutting a release. The mechanics referenced here are det
 
 - **Version:** `0.1.0` — already set in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`. No bump needed.
 - **Distribution:** signed + notarized `.dmg`, manual download.
-- **Auto-update: deferred.** The updater public key ships, but the endpoint (`agency-agents-app.zerologic.com/updater.json`) is not yet provisioned. Build with `SKIP_UPDATER=1` so no updater artifact/manifest is expected. A later release turns auto-update on once the endpoint serves a manifest.
+- **Auto-update: deferred.** The updater public key ships, but the endpoint (`agencyagents.app/updater.json`) is not yet provisioned. Build with `SKIP_UPDATER=1` so no updater artifact/manifest is expected. A later release turns auto-update on once the endpoint serves a manifest.
 - **Out of scope (known limitations, noted in the release notes):** auto-update, multi-file renderers (antigravity / openclaw / aider / windsurf), Windows/Linux runtime verification, and the local-runtime (Ollama / LM Studio) target.
 
 ### Steps

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -116,8 +116,11 @@ The exact filename may vary by version and architecture.
 Agency Agents uses `tauri-plugin-updater`. The configured endpoint is:
 
 ```text
-https://agency-agents-app.zerologic.com/updater.json
+https://agencyagents.app/updater.json
 ```
+
+Served by Caddy on `umacbookpro` from `~/Sites/agency-agents/` (the `agencyagents.app`
+docroot) — the same box and pattern as the live `brew-browser.zerologic.com/updater.json`.
 
 The updater artifact is a gzipped `.app` tarball, not the `.dmg`.
 
@@ -127,7 +130,8 @@ Manifest generation is handled by:
 tools/release/publish-manifest.sh <version>
 ```
 
-The updater public key is embedded in the app config/source. The matching private key must live outside the repo, for example:
+The updater public key is embedded in the app config/source. The matching private key lives outside
+the repo:
 
 ```text
 ~/.config/agency-agents-app/updater.key
@@ -172,9 +176,17 @@ The ordered runbook for cutting a release. The mechanics referenced here are det
 
 ### Enabling auto-update (a later release)
 
-1. Provision `agency-agents-app.zerologic.com/updater.json` to serve the manifest.
-2. Confirm the updater private key is available (Keychain, or `~/.config/agency-agents-app/updater.key`).
-3. Build **without** `SKIP_UPDATER`, then run `tools/release/publish-manifest.sh <version>` and host the gzipped `.app` tarball + manifest at the endpoint.
+1. Hosting is already provisioned: Caddy on `umacbookpro` serves `agencyagents.app` from
+   `~/Sites/agency-agents/`, so publishing the manifest is just an `rsync` of `updater.json`
+   into that docroot (mirrors the live `brew-browser` manifest).
+2. The updater signature uses agency's own minisign key at `~/.config/agency-agents-app/updater.key`
+   (its public half is embedded in `tauri.conf.json` → `plugins.updater.pubkey`). Source
+   `~/.config/agency-agents-app/signing.env` before the build — it exports
+   `TAURI_SIGNING_PRIVATE_KEY[_PATH]` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`. Apple notarization
+   uses the Developer ID identity in the login keychain.
+3. Build **without** `SKIP_UPDATER`, run `tools/release/publish-manifest.sh <version>`, attach the
+   gzipped `.app` tarball to the GitHub release, then `rsync` `dist/updater.json` to
+   `umacbookpro:Sites/agency-agents/updater.json`.
 
 ## macOS Icon Notes
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -120,7 +120,8 @@ https://agencyagents.app/updater.json
 ```
 
 Served by Caddy on `umacbookpro` from `~/Sites/agency-agents/` (the `agencyagents.app`
-docroot) — the same box and pattern as the live `brew-browser.zerologic.com/updater.json`.
+docroot). This is the same Caddy `file_server` box that already serves the live
+`brew-browser.zerologic.com/updater.json` from a sibling vhost — the pattern is proven.
 
 The updater artifact is a gzipped `.app` tarball, not the `.dmg`.
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -130,15 +130,16 @@ Implement special output shapes only after their path semantics are verified:
 
 Tracked inventory for the release after v0.2.0. Grouped by what unblocks each item.
 
-### Auto-update (present today, intentionally disabled)
+### Auto-update
 
-The updater UI, store, plugin, public key, and `SKIP_UPDATER=1` build path all ship. What's left:
+The updater UI, store, plugin, dedicated signing key, and publish tooling all ship.
 
-1. **Provision the endpoint** — host `agencyagents.app/updater.json` + the signed `.app` tarball, then
-   build without `SKIP_UPDATER`. *Blocked on infra (hosting + the minisign private key), not code.*
-2. **Opt-in automatic install** — today "Auto-check daily" only surfaces a title-bar notice; the user
-   still clicks Install. Add an "Install updates automatically" toggle, **off by default** (present but
-   disabled until the endpoint is live). Backend install/relaunch plumbing already exists.
+1. **Endpoint — activated at the v0.2.0 release cut** (no longer post-0.2.0): host is `agencyagents.app`
+   (Caddy on umbp from `~/Sites/agency-agents/`), the v0.2.0 build runs without `SKIP_UPDATER`, and
+   `publish-manifest.sh` rsyncs the signed manifest there. Resolved in `decisions.md` (2026-06-22).
+2. **Opt-in automatic install** *(remaining)* — today the live path is check → notify → one-click Install;
+   the user still clicks. Wire the inert "Install updates automatically" toggle to a real off-by-default
+   setting that does background download → verify → install. Backend install/relaunch plumbing exists.
 3. **Beta channel** — "Update channel: Stable" is a read-only placeholder; wire real channel selection.
 4. **Bulk-install auto-deploy** (separate idea) — a subscription that auto-deploys newly-added catalog
    agents into a division/team/project. Distinct from app self-update.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -19,21 +19,25 @@ The app should answer three questions clearly:
 ## Current Architecture
 
 ```text
-Svelte UI
+Svelte UI                      four pillars: Agents / Tools / Teams / Projects
   Agents workspace
   Tools panel
+  Teams (preset + saved)
+  Projects (project-scoped installs)
   Dashboard
-  Loadouts
+  Playbook
   Settings
       |
       | typed Tauri IPC
       v
 Rust backend
   corpus/     catalog source, refresh, indexing
-  render/     deterministic tool renderers
+  registry    single-source tools.json (shared with the frontend)
+  render/     deterministic tool renderers (format-dispatched)
   install/    write, uninstall, backups, ledger, reconcile
   github/     optional OAuth + GitHub API features
   settings/   local settings and network gates
+  updater/    manifest fetch + minisign verify (present, endpoint not yet live)
       |
       v
 Local filesystem
@@ -68,7 +72,7 @@ Out of scope for the current release:
 
 ## Supported Renderer Set
 
-Current app-supported targets:
+Current app-supported (installable) targets — 8:
 
 - Claude Code
 - Codex
@@ -77,10 +81,11 @@ Current app-supported targets:
 - Qwen Code
 - Cursor
 - opencode
+- Osaurus (`skill-md` → `~/.osaurus/skills/agency-<slug>/SKILL.md`)
 
-Known AA repo targets that still need app support:
+Known AA repo targets that still need app support (recognized-only in the Tools panel) — 5:
 
-- Antigravity
+- Antigravity — blocked on upstream: `convert_antigravity()` still stamps a non-deterministic `date_added: '${TODAY}'`, so byte-parity is impossible until that field is removed or made deterministic.
 - Aider
 - Windsurf
 - OpenClaw
@@ -102,28 +107,14 @@ Mostly done. macOS retains overlay titlebar and vibrancy. Windows/Linux use opaq
 
 ### Phase D: Tool Target Manifest
 
-Next recommended architecture step.
+Done (v0.2.0). Shipped as the upstream-owned single `tools.json` — the twin of `divisions.json` —
+declaring id, label, scopes, detect paths, version probe, output format, and destinations per tool.
+Both the Rust backend (`registry`) and the frontend read it; the Rust `Tool` enum is gone and the
+renderer dispatches on `format`. Installability is derived (`format ∈ IMPLEMENTED_FORMATS`), not stored.
+Upstream guards drift with `scripts/check-tools.sh` (the no-jq twin of `check-divisions.sh`).
 
-Create a manifest in the AA repo that declares:
-
-- tool ID
-- label
-- vendor
-- support status
-- scopes
-- default paths
-- env overrides
-- output format
-- renderer kind
-- authoritative docs/source links
-- verification status
-
-Then:
-
-- update `agency-agents/scripts/install.sh` to consume it for tool metadata and paths
-- add an audit script that checks manifest drift
-- update this app's Tools panel to consume generated manifest metadata
-- keep Rust writes limited to renderers the app can safely implement and test
+Remaining: the app bundles a baseline copy of `tools.json` — it should refresh from the catalog clone
+at runtime (like the corpus), and aa's `check-tools.yml` CI workflow is still staged to land.
 
 ### Phase E: Multi-File Renderers
 
@@ -134,6 +125,49 @@ Implement special output shapes only after their path semantics are verified:
 - OpenClaw workspace directory
 - Antigravity skill directories
 - Kimi if current docs validate an installable custom-agent format
+
+## Post-0.2.0 Punch List
+
+Tracked inventory for the release after v0.2.0. Grouped by what unblocks each item.
+
+### Auto-update (present today, intentionally disabled)
+
+The updater UI, store, plugin, public key, and `SKIP_UPDATER=1` build path all ship. What's left:
+
+1. **Provision the endpoint** — host `agencyagents.app/updater.json` + the signed `.app` tarball, then
+   build without `SKIP_UPDATER`. *Blocked on infra (hosting + the minisign private key), not code.*
+2. **Opt-in automatic install** — today "Auto-check daily" only surfaces a title-bar notice; the user
+   still clicks Install. Add an "Install updates automatically" toggle, **off by default** (present but
+   disabled until the endpoint is live). Backend install/relaunch plumbing already exists.
+3. **Beta channel** — "Update channel: Stable" is a read-only placeholder; wire real channel selection.
+4. **Bulk-install auto-deploy** (separate idea) — a subscription that auto-deploys newly-added catalog
+   agents into a division/team/project. Distinct from app self-update.
+
+### Catalog / registry
+
+5. Refresh `tools.json` from the catalog clone at runtime instead of bundling a baseline copy.
+6. Land `check-tools.yml` CI upstream (aa repo).
+7. Foreign-sweep for nested `…/<dir>/SKILL.md` skills — CLI-installed Osaurus/Antigravity aren't
+   auto-detected; app-installed ones are.
+
+### New install targets (recognized → installable)
+
+8. Multi-file renderers per Phase E (Aider, Windsurf, OpenClaw, Kimi).
+9. Antigravity — *blocked on upstream* removing the non-deterministic `date_added`.
+
+### Platform / packaging
+
+10. Windows code signing — *blocked on a paid cert*.
+11. Native runtime verification on Windows/Linux VMs (Phase C remainder).
+
+### Accessibility (pre-existing)
+
+12. Bulk-delete dialog focus management.
+13. `role=menu` keyboard navigation.
+
+### Longer horizon
+
+14. Local-runtime system-prompt target (Ollama / LM Studio).
 
 ## Quality Gates
 

--- a/docs/release-notes/0.2.0.md
+++ b/docs/release-notes/0.2.0.md
@@ -42,6 +42,10 @@ Or visit [agencyagents.app](https://agencyagents.app).
 
 - A two-ring Global-vs-Projects install sunburst so the totals reconcile, cross-tool coverage merged with the catalog-by-division view into one card with linked hover, and uniform donut sizing.
 
+**Auto-update goes live:**
+
+- This release activates the in-app updater. It publishes a signed manifest at `agencyagents.app/updater.json` (signed with a dedicated agency key), and the app checks for new versions and offers a one-click download → verify → install → relaunch, surfaced via a title-bar indicator and Settings → Updates. Because v0.2.0 is the first build with a live endpoint, the first *delivered* update will be the next release — a v0.2.0 user checking now correctly sees "up to date." Fully hands-off automatic install (the "Install updates automatically" toggle) is present but still disabled; opt-in auto-install lands later.
+
 ### Quality Gates
 
 - `cargo test --lib` (264 passing, incl. renderer byte-parity)
@@ -58,7 +62,8 @@ Or visit [agencyagents.app](https://agencyagents.app).
 - CLI-installed Osaurus skills are not yet auto-detected by Foreign-sweep; app-installed ones are tracked normally.
 - **Windows: the build is not code-signed yet.** On first launch Microsoft Defender SmartScreen will show
   "Windows protected your PC". To run it: click **More info → Run anyway**.
-- **Auto-update is still disabled.** As in v0.1.0, this release ships with the updater present but inactive
-  (`SKIP_UPDATER=1`; the `agencyagents.app/updater.json` endpoint is not yet provisioned). The Settings
-  → Updates surface and the title-bar indicator are in place; turning the channel on — including opt-in
-  automatic installs — is tracked for the next release.
+- **Auto-update is live (new in 0.2.0).** The app fetches a signed manifest from
+  `agencyagents.app/updater.json` and offers one-click install + relaunch when a newer version is
+  published. v0.1.0 users upgrade to v0.2.0 manually (the older build predates the live endpoint and the
+  dedicated signing key); auto-update is real from v0.2.0 forward. Fully hands-off automatic install (the
+  "Install updates automatically" toggle) is present but disabled — opt-in auto-install lands later.

--- a/docs/release-notes/0.2.0.md
+++ b/docs/release-notes/0.2.0.md
@@ -1,0 +1,64 @@
+## Agency Agents v0.2.0 — 2026-06-22
+
+The first feature release since the public launch. This is a large one: it reorganizes the app
+around a four-pillar model, makes tool knowledge a single source of truth, wires a new install
+target (Osaurus), and adds an in-app Playbook for getting real work out of the catalog.
+
+This rolls up everything developed after v0.1.0 (the milestones tracked internally as 0.1.1 and
+0.1.2 were never cut as separate releases — they ship here).
+
+### Downloads
+
+- **macOS** (Apple Silicon & Intel) — signed + notarized `.dmg`, launches without warnings. macOS 13+.
+- **Linux** (x86_64) — `.deb` (Debian/Ubuntu), `.rpm` (Fedora/RHEL/openSUSE), or the portable `.AppImage`.
+- **Windows** (x64 & ARM64) — `.exe` installer. Not code-signed yet, so SmartScreen warns on first launch → click **More info → Run anyway** (see Known Notes).
+
+Or visit [agencyagents.app](https://agencyagents.app).
+
+### Highlights
+
+**A four-pillar information architecture — Agents / Tools / Teams / Projects (who / how / which / where):**
+
+- **Divisions landing** — the catalog now opens on its divisions, with an install-state lens (installed / not-installed / all) layered across the workspace.
+- **Teams** (renamed from Loadouts) — app-bundled preset teams plus your own saved teams; click a team for a detail panel with Deploy built in.
+- **Projects pillar** — project-scoped installs with a dedicated Projects panel and master/detail navigation driven by the system back arrow.
+- **Unified install surface** — a single destinations × tools Install grid reused everywhere, plus a two-pane Deploy browser grouped by division.
+
+**Tool registry — a single source of truth:**
+
+- Tool knowledge now lives in one upstream-owned `tools.json` (the twin of the catalog's `divisions.json`), read by both the Rust backend and the frontend. The Rust `Tool` enum is gone — a tool is an id, and the renderer dispatches on a `format` key. **Adding a tool is now editing one JSON file.**
+- All 13 recognized tools are modeled and shown in the Tools panel; installable targets render in full, recognized-only targets appear dimmed. Installability is derived from whether the app ships a renderer for the tool's format — nothing to hand-sync.
+- Real brand logos for tools, vendored from Lobe Icons (MIT).
+
+**Osaurus support:**
+
+- A new `skill-md` renderer installs catalog agents as native Osaurus skills (`~/.osaurus/skills/agency-<slug>/SKILL.md`), byte-identical to the upstream converter. That brings the installable target count to 8.
+
+**Playbook:**
+
+- An in-app Playbook (title-bar book icon / ⌘K) with best practices and copyable starter prompts for directing the catalog, plus per-team and per-division examples. Also documented in [docs/USING-AGENTS.md](../USING-AGENTS.md).
+
+**Dashboard:**
+
+- A two-ring Global-vs-Projects install sunburst so the totals reconcile, cross-tool coverage merged with the catalog-by-division view into one card with linked hover, and uniform donut sizing.
+
+### Quality Gates
+
+- `cargo test --lib` (264 passing, incl. renderer byte-parity)
+- `npm run check` (0 errors)
+- `npm run build`
+- ignored renderer parity test against the active `agency-agents` clone
+- Phase C platform-config validation
+- full cross-platform build matrix (macOS + Ubuntu deb/rpm/appimage + Windows x64/arm64)
+
+### Known Release Notes
+
+- The app is not an agent runtime — it installs personas into other tools; it does not execute them.
+- Five upstream targets remain recognized-only (Antigravity, Aider, Windsurf, OpenClaw, Kimi); they need additional renderer work before they're exposed as first-class installs.
+- CLI-installed Osaurus skills are not yet auto-detected by Foreign-sweep; app-installed ones are tracked normally.
+- **Windows: the build is not code-signed yet.** On first launch Microsoft Defender SmartScreen will show
+  "Windows protected your PC". To run it: click **More info → Run anyway**.
+- **Auto-update is still disabled.** As in v0.1.0, this release ships with the updater present but inactive
+  (`SKIP_UPDATER=1`; the `agencyagents.app/updater.json` endpoint is not yet provisioned). The Settings
+  → Updates surface and the title-bar indicator are in place; turning the channel on — including opt-in
+  automatic installs — is tracked for the next release.

--- a/memory-bank/decisions.md
+++ b/memory-bank/decisions.md
@@ -116,12 +116,26 @@ bypassed only when `TAURI_CONFIG` is set, and only with the `false` value). **Co
 green from cold; the Tauri CLI sets its own process-env `TAURI_CONFIG` (precedence over `[env]`), so real
 `tauri dev`/`build` use the merged config (`macOSPrivateApi: true`) — verified `tauri dev` launches clean.
 
-### OPEN: updater endpoint host (+ confirm private key)
-The minisign **pubkey** in `tauri.conf.json` is now a real key (no longer the brew placeholder). What
-remains before auto-update works: provision `agency-agents-app.zerologic.com/updater.json` to serve a
-manifest, and confirm the matching **private key** is available (Keychain `agency-agents-updater-key`,
-or `~/.config/agency-agents-app/updater.key`). Until then, build with `SKIP_UPDATER=1` (updater inert —
-fine for v0.1.0's manual DMG).
+### 2026-06-22: Updater host = `agencyagents.app`; dedicated agency signing key (resolves the OPEN host ADR)
+**Status**: Approved (v0.2.0). **Context**: the prior OPEN entry assumed the endpoint would be
+`agency-agents-app.zerologic.com` and that the embedded pubkey was a one-off real key. Tracing the live
+build host settled both. **Decision (host — the important detail)**: the updater endpoint is
+**`https://agencyagents.app/updater.json`**, NOT the `…zerologic.com` host the UI/docs/source comments
+had drifted to. It is already in `tauri.conf.json` `endpoints` + the CSP `connect-src`, and Caddy on
+`umacbookpro` serves `agencyagents.app` from `~/Sites/agency-agents/` (a sibling vhost to the live
+`brew-browser.zerologic.com/updater.json`, so the file_server pattern is proven). Publishing is an
+`rsync` of `dist/updater.json` to `umacbookpro:Sites/agency-agents/updater.json`. **Decision (key)**:
+the embedded pubkey was byte-identical to brew-browser's shared key (id `7335DD0F`); swapped to a
+**dedicated agency minisign key** (id `ABF5AFD8`) generated on the build machine — clean signing
+isolation, done now while NO updater client is live (endpoint never served a manifest under
+`SKIP_UPDATER`), so there is zero continuity cost. Private key + `signing.env` live at
+`~/.config/agency-agents-app/` (chmod 600, outside the repo); Apple notarization uses the Developer ID
+identity in the login keychain. The Rust `UPDATER_PUBKEY` const (`lib.rs`) is kept in sync with
+`tauri.conf.json` for documentation only — verification is driven entirely by the conf value the
+`tauri-plugin-updater` reads at startup. **Consequences**: v0.1.0 users (old embedded pubkey, and no
+manifest ever existed) upgrade to v0.2.0 manually; auto-update is real from v0.2.0 forward. **Remaining
+before live**: build without `SKIP_UPDATER`, run `tools/release/publish-manifest.sh`, host the signed
+`.app.tar.gz` + manifest. Until then the updater ships present-but-disabled.
 
 ### 2026-06-16: Defer Windows code signing for v0.1.0
 **Status**: Approved. **Context**: v0.1.0 is a Mac-first manual release (signed/notarized DMG); Windows is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agency-agents-app",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Agency Agents — a native macOS app store for AI agents. Browse, install, and track 251+ specialized agents across every AI coding tool.",
   "type": "module",
   "author": "Michael Sitarzewski",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agency-agents-app"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agency-agents-app"
-version = "0.1.0"
+version = "0.2.0"
 description = "Agency Agents — a native macOS app store for AI agents."
 authors = ["Michael Sitarzewski"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,8 +33,8 @@ use commands::*;
 //
 // The matching public key the command prints is what goes here.
 // Keep the private key chmod 600 outside the repo — it's the only
-// thing standing between a compromised agency-agents-app.zerologic.com
-// and a malicious binary push.
+// thing standing between a compromised agencyagents.app and a
+// malicious binary push.
 //
 // Real minisign public key. The matching private key lives at
 // `~/.config/agency-agents-app/updater.key` (chmod 600,
@@ -46,7 +46,7 @@ use commands::*;
 // at startup; keep both in sync. The plugin parses Tauri's base64-of-
 // minisign-blob format directly — what you see here is exactly what
 // `tauri signer generate -w …` printed.
-const UPDATER_PUBKEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDczMzVERDBGRDAzQTRBNkEKUldScVNqclFEOTAxYy9DYTg5QThJR2JWWHJZSWdWMXRkckFlUDAyVHpxcjgwWXVHaUQ2VlNGcHgK";
+const UPDATER_PUBKEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEFCRjVBRkQ4ODhFRDI5QkQKUldTOUtlMkkySy8xcTlyRnNjM1pkMy9sc2NkMzdOOVlhTEd5OTVoNFIwWDI4VUROUGhVbFNuMzMK";
 
 pub fn updater_pubkey() -> &'static str {
     UPDATER_PUBKEY

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
       "endpoints": [
         "https://agencyagents.app/updater.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDczMzVERDBGRDAzQTRBNkEKUldScVNqclFEOTAxYy9DYTg5QThJR2JWWHJZSWdWMXRkckFlUDAyVHpxcjgwWXVHaUQ2VlNGcHgK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEFCRjVBRkQ4ODhFRDI5QkQKUldTOUtlMkkySy8xcTlyRnNjM1pkMy9sc2NkMzdOOVlhTEd5OTVoNFIwWDI4VUROUGhVbFNuMzMK"
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Agency Agents",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.zerologic.agency-agents-app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/SettingsSectionNetwork.svelte
+++ b/src/lib/components/SettingsSectionNetwork.svelte
@@ -55,7 +55,7 @@
         allowed: !paranoid,
       },
       {
-        label: "agency-agents-app.zerologic.com",
+        label: "agencyagents.app",
         desc: "App update checks — the signed updater manifest. Honors your update settings below.",
         allowed: !paranoid,
       },

--- a/src/lib/components/SettingsSectionUpdates.svelte
+++ b/src/lib/components/SettingsSectionUpdates.svelte
@@ -77,7 +77,7 @@
       see the changelog + assets even when the manifest snippet is
       terse. */
   let releaseNotesUrl = $derived(
-    info ? `https://github.com/msitarzewski/Agency Agents/releases/tag/v${info.version}` : null,
+    info ? `https://github.com/msitarzewski/agency-agents-app/releases/tag/v${info.version}` : null,
   );
 
   function onOpenReleaseNotes() {
@@ -123,7 +123,7 @@
       </p>
     {:else}
       <p class="hint">
-        Fetches <code>agency-agents-app.zerologic.com/updater.json</code> and
+        Fetches <code>agencyagents.app/updater.json</code> and
         compares the published version to the one you're running. No
         version number is sent.
       </p>
@@ -146,6 +146,28 @@
       When on, Agency Agents checks the manifest once every 24 hours and
       surfaces a notice in the title bar if a newer version is available.
       Suspended automatically while Offline Mode is on.
+    </p>
+  </div>
+
+  <!-- Row 2b: Install updates automatically — present but disabled.
+       No backing setting yet; the toggle is inert until the update
+       channel is live (endpoint provisioned + auto-install wired). It
+       ships now so the capability is visible and the layout is settled. -->
+  <div class="field">
+    <label class="toggle is-disabled">
+      <input
+        type="checkbox"
+        checked={false}
+        disabled
+        aria-describedby="auto-install-hint"
+      />
+      <span class="toggle-track" aria-hidden="true"></span>
+      <span class="toggle-label">Install updates automatically</span>
+    </label>
+    <p class="hint" id="auto-install-hint">
+      Available once the update channel is live. When enabled, approved updates
+      will download, verify, and install in the background — you'll only be
+      prompted to relaunch.
     </p>
   </div>
 
@@ -284,6 +306,8 @@
     user-select: none;
   }
   .toggle input { position: absolute; opacity: 0; pointer-events: none; }
+  /* Inert "Install updates automatically" row — visible, clearly off. */
+  .toggle.is-disabled { opacity: 0.55; cursor: not-allowed; }
   .toggle-track {
     width: 36px;
     height: 20px;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -174,7 +174,7 @@ export interface CreatedIssue {
 
 /**
  * A newer Agency Agents version surfaced by the manifest at
- * `agency-agents-app.zerologic.com/updater.json`. Held by the updater store
+ * `agencyagents.app/updater.json`. Held by the updater store
  * once a check returns `available`. Matches the camelCase wire shape
  * the backend's `UpdateCheckOutcome::Available` flattens onto when
  * serde-tagged with `kind`.

--- a/tools/release/publish-manifest.sh
+++ b/tools/release/publish-manifest.sh
@@ -35,8 +35,9 @@
 #          }
 #        }
 #   6. Echoes (but does NOT execute) the rsync command the user runs
-#      to publish the manifest to agency-agents-app.zerologic.com via
-#      umacbookpro:Sites/agency-agents-app/updater.json. Publishing is a
+#      to publish the manifest to agencyagents.app via
+#      umacbookpro:Sites/agency-agents/updater.json (the Caddy docroot
+#      for agencyagents.app). Publishing is a
 #      deliberate manual step.
 #
 # What it does NOT do:
@@ -105,7 +106,8 @@ if [[ ! -f "$SIGNATURE_FILE" ]]; then
     echo "error: updater signature not found at $SIGNATURE_FILE" >&2
     echo "  The Tauri bundler produces this when TAURI_SIGNING_PRIVATE_KEY[_PATH]" >&2
     echo "  + TAURI_SIGNING_PRIVATE_KEY_PASSWORD are set during 'npm run tauri build'." >&2
-    echo "  Source ~/.config/agency-agents-app/signing.env, then re-run the build." >&2
+    echo "  Source ~/.config/agency-agents-app/signing.env (exports TAURI_SIGNING_PRIVATE_KEY" >&2
+    echo "  [_PATH] + _PASSWORD for the agency updater key), then re-run the build." >&2
     exit 2
 fi
 
@@ -171,7 +173,7 @@ echo "  pub_date:   $PUB_DATE"
 echo "  signature:  $(wc -c < "$SIGNATURE_FILE" | tr -d ' ') bytes from $SIGNATURE_FILE"
 echo ""
 echo "next steps (run manually):"
-echo "  1. rsync -av $MANIFEST_PATH umacbookpro:Sites/agency-agents-app/updater.json"
+echo "  1. rsync -av $MANIFEST_PATH umacbookpro:Sites/agency-agents/updater.json"
 echo "  2. gh release create v${VERSION} \\"
 echo "       src-tauri/target/release/bundle/dmg/Agency\\ Agents_${VERSION}_aarch64.dmg \\"
 echo "       $ARTIFACT_PATH#${ARTIFACT_RELEASE_NAME} \\"
@@ -179,4 +181,4 @@ echo "       --notes-file <release-notes.md>"
 echo ""
 echo "verify before publishing:"
 echo "  shasum -a 256 $ARTIFACT_PATH"
-echo "  curl -s https://agency-agents-app.zerologic.com/updater.json | jq"
+echo "  curl -s https://agencyagents.app/updater.json | jq"


### PR DESCRIPTION
First feature release since the public **v0.1.0** launch. The manifests still said `0.1.0` and the only tag is `v0.1.0`, so this is the *first* release since launch — and it carries everything built since (the milestones tracked internally as 0.1.1/0.1.2 were never cut separately; they ship here). Given the diff, this is a minor bump, not a patch.

## What's in the release
- **Four-pillar IA** — Agents / Tools / Teams / Projects (who / how / which / where): divisions landing, install-state lens, Teams (← Loadouts), the Projects pillar, the unified Install grid, the two-pane Deploy browser.
- **Tool registry** — a single upstream-owned `tools.json` (twin of `divisions.json`) read by both backend and frontend; the Rust `Tool` enum is gone; installability is **derived** from `format ∈ IMPLEMENTED_FORMATS`. Byte-identical to aa `main` @ #606.
- **Osaurus** wired via a new `skill-md` renderer (8 installable / 5 recognized).
- **Playbook** + `docs/USING-AGENTS.md`.
- **Dashboard** — Global-vs-Projects sunburst, merged cross-tool/catalog card.

## This PR — release prep + updater wiring

**Release prep**
- Version `0.1.0` → `0.2.0` across `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`.
- New `docs/release-notes/0.2.0.md` (consolidated).
- README features pass (four-pillar, Teams, Projects, registry, Osaurus install-target row).
- `docs/PLAN.md` refresh — Phase D marked done, diagram updated, **post-0.2.0 punch list** recorded.

**Updater (infrastructure wired, still disabled in this build)**
- Corrected stale `zerologic.com` host → `agencyagents.app` (the configured + CSP-allowed endpoint; the Settings hint was wrong) and fixed the 404 release-notes URL.
- Retargeted `publish-manifest.sh` + `BUILD.md` to the **real serving path** (verified on the build host): Caddy serves `agencyagents.app` from `~/Sites/agency-agents/`, so the rsync target is `umacbookpro:Sites/agency-agents/updater.json`.
- **Dedicated agency signing key** (`ABF5AFD8…`) embedded — swapped off the key shared with brew-browser while no updater clients are live, for clean signing isolation. Private key stays in `~/.config/agency-agents-app/` (untracked).
- **Inert "Install updates automatically" row** — present but disabled, ahead of activating the channel.

Auto-update still ships **present but disabled** (`SKIP_UPDATER=1`), same posture as v0.1.0 — the endpoint isn't published yet. Turning it on is a deliberate post-merge step.

## Quality gates
- `npm run check` → 0 errors
- `cargo test --lib` → 264 passed
- `Cargo.toml` base deps clean (no `macos-private-api` injection)
- bundled `tools.json` byte-identical to aa `main`
- embedded updater pubkey verified == `~/.config/agency-agents-app/updater.key.pub`

## Not in this PR (post-0.2.0 punch list, in `docs/PLAN.md`)
Publishing the updater manifest + opt-in auto-install wiring, multi-file renderers, Antigravity (blocked upstream on non-deterministic `date_added`), Windows signing, Ollama/LM Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)