### PR TITLE
fix(release): updater-enabled macOS builds + Keychain docs

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -49,43 +49,54 @@ The release build produces a signed `.app` and `.dmg`.
 
 ### Prerequisites
 
+`scripts/release.sh` reads **every secret from the macOS Keychain** — nothing lives in the repo
+or an env file. The non-secret `APPLE_ID` / `APPLE_TEAM_ID` are hardcoded in the script. One-time setup:
+
 1. Apple Developer ID Application certificate in the login keychain:
 
    ```sh
    security find-identity -v -p codesigning
    ```
 
-2. App-specific Apple password generated at <https://appleid.apple.com>.
-
-3. Signing environment outside the repo:
-
-   ```sh
-   mkdir -p ~/.config/agency-agents-app
-   chmod 700 ~/.config/agency-agents-app
-   ```
-
-   Create `~/.config/agency-agents-app/signing.env`:
+2. Apple notarization password — an app-specific password from <https://appleid.apple.com>
+   (Sign-In and Security → App-Specific Passwords), stored in the Keychain:
 
    ```sh
-   export APPLE_ID="your@email.com"
-   export APPLE_PASSWORD="xxxx-xxxx-xxxx-xxxx"
-   export APPLE_TEAM_ID="XXXXXXXXXX"
-   # Optional:
-   # export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+   security add-generic-password -a "<apple-id>" -s "agency-agents-notary" -U -w
+   # paste the app-specific password when prompted
    ```
 
-   Then:
+3. Updater signing key — the minisign key whose public half is embedded in `tauri.conf.json`.
+   Generate it once (writes the canonical key file), then store the key **and** its password in
+   the Keychain:
 
    ```sh
-   chmod 600 ~/.config/agency-agents-app/signing.env
+   npm run tauri -- signer generate -w ~/.config/agency-agents-app/updater.key
+   # paste the PUBLIC key it prints into tauri.conf.json → plugins.updater.pubkey
+
+   security add-generic-password -a agency-agents -s agency-agents-updater-key    -U -w "$(cat ~/.config/agency-agents-app/updater.key)"
+   security add-generic-password -a agency-agents -s agency-agents-updater-key-pw -U -w
+   # (paste the key's password for the second one)
    ```
+
+   Store the key via `$(cat …)`, not a manual paste — a stray trailing newline corrupts it and
+   signing fails with `incorrect updater private key password: Invalid input`. (Repair script:
+   re-run the `agency-agents-updater-key` line above from the canonical file.)
 
 ### Build
 
 ```sh
-source ~/.config/agency-agents-app/signing.env
 ./scripts/release.sh
 ```
+
+That's it — `release.sh` pulls the notary + updater secrets from the Keychain, then builds, signs,
+notarizes, staples, and (unless `SKIP_UPDATER=1`) emits the signed updater artifacts. It builds both
+Mac arches by default; override with e.g. `RELEASE_TARGETS="aarch64-apple-darwin"`.
+
+> **Intel cross-compile** needs the **rustup** toolchain — Homebrew's `rust` is host-only and yields
+> `can't find crate for core` for `x86_64-apple-darwin`. Add the target once
+> (`rustup target add x86_64-apple-darwin`) and run with
+> `PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" RELEASE_TARGETS="x86_64-apple-darwin" ./scripts/release.sh`.
 
 If using the lower-level Tauri build directly:
 
@@ -131,8 +142,9 @@ Manifest generation is handled by:
 tools/release/publish-manifest.sh <version>
 ```
 
-The updater public key is embedded in the app config/source. The matching private key lives outside
-the repo:
+The updater public key is embedded in the app config/source. The matching private key is read from
+the **Keychain** at build time (`agency-agents-updater-key` + `…-key-pw`); the canonical key file it
+was generated from is kept outside the repo (chmod 600) as the backup of record:
 
 ```text
 ~/.config/agency-agents-app/updater.key
@@ -175,19 +187,20 @@ The ordered runbook for cutting a release. The mechanics referenced here are det
 
 7. **Post-release** — log the cut in `memory-bank/agentLog.md`; open the next milestone for the deferred items (updater endpoint, Phase 5 quality gate).
 
-### Enabling auto-update (a later release)
+### Auto-update publishing
 
-1. Hosting is already provisioned: Caddy on `umacbookpro` serves `agencyagents.app` from
-   `~/Sites/agency-agents/`, so publishing the manifest is just an `rsync` of `updater.json`
-   into that docroot (mirrors the live `brew-browser` manifest).
-2. The updater signature uses agency's own minisign key at `~/.config/agency-agents-app/updater.key`
-   (its public half is embedded in `tauri.conf.json` → `plugins.updater.pubkey`). Source
-   `~/.config/agency-agents-app/signing.env` before the build — it exports
-   `TAURI_SIGNING_PRIVATE_KEY[_PATH]` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`. Apple notarization
-   uses the Developer ID identity in the login keychain.
-3. Build **without** `SKIP_UPDATER`, run `tools/release/publish-manifest.sh <version>`, attach the
-   gzipped `.app` tarball to the GitHub release, then `rsync` `dist/updater.json` to
-   `umacbookpro:Sites/agency-agents/updater.json`.
+Auto-update went live in **v0.2.0** — the manifest at `agencyagents.app/updater.json` covers both Mac
+arches. The release-time flow:
+
+1. Hosting is provisioned: Caddy on `umacbookpro` serves `agencyagents.app` from `~/Sites/agency-agents/`,
+   so publishing is an `rsync` of `updater.json` into that docroot (mirrors the live `brew-browser` manifest).
+2. The signature uses agency's minisign key (public half embedded in `tauri.conf.json`). `release.sh`
+   reads the private key + password from the **Keychain** (`agency-agents-updater-key` / `…-key-pw`) — no
+   env file is sourced; Apple notarization uses the Developer ID identity in the login keychain.
+3. Build **without** `SKIP_UPDATER`, run `tools/release/publish-manifest.sh <version>`, attach the gzipped
+   `.app` tarball(s) to the GitHub release, then `rsync` `dist/updater.json` to
+   `umacbookpro:Sites/agency-agents/updater.json`. `publish-manifest.sh` emits the `darwin-aarch64` entry;
+   for Intel, sign the x64 `.app.tar.gz` and add a `darwin-x86_64` entry to the manifest by hand.
 
 ## macOS Icon Notes
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -55,10 +55,16 @@ export APPLE_PASSWORD
 # auto-update bundle and REQUIRES the minisign private key. SKIP_UPDATER=1
 # turns the updater artifact OFF for this build (config override) so the run
 # exits clean with just the signed+notarized .app/.dmg.
-BUILD_ARGS=()
+# A --config flag forces the tauri CLI to fully re-resolve the config, which
+# auto-merges tauri.macos.conf.json (where macOSPrivateApi:true lives) into the
+# config the build-script allowlist check reads. Without ANY --config, that
+# check sees only base tauri.conf.json (no macOSPrivateApi) and rejects the
+# macos-private-api feature from the [target.macos] block — see tauri#11142.
+# (This is why every SKIP_UPDATER build worked but the updater-on path did not.)
+BUILD_ARGS=(--config '{"app":{"macOSPrivateApi":true}}')
 if [[ "${SKIP_UPDATER:-0}" == "1" ]]; then
   echo "▸ SKIP_UPDATER=1 — building WITHOUT updater artifacts."
-  BUILD_ARGS=(--config '{"bundle":{"createUpdaterArtifacts":false}}')
+  BUILD_ARGS+=(--config '{"bundle":{"createUpdaterArtifacts":false}}')
 else
   TAURI_SIGNING_PRIVATE_KEY="$(kc "agency-agents" "$UPDATER_KEY_SERVICE")"
   TAURI_SIGNING_PRIVATE_KEY_PASSWORD="$(kc "agency-agents" "$UPDATER_KEY_PW_SERVICE")"
@@ -91,11 +97,11 @@ DMG_DIRS=()
 for target in "${TARGETS[@]}"; do
   if [[ "$target" == "$HOST_TRIPLE" ]]; then
     echo "▸ Building signed + notarized Agency Agents for ${target} (native, Team $APPLE_TEAM_ID)…"
-    npm run tauri build -- "${BUILD_ARGS[@]}"
+    npm run tauri build -- ${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}
     DMG_DIRS+=("src-tauri/target/release/bundle/dmg/")
   else
     echo "▸ Building signed + notarized Agency Agents for ${target} (cross, Team $APPLE_TEAM_ID)…"
-    npm run tauri build -- --target "$target" "${BUILD_ARGS[@]}"
+    npm run tauri build -- --target "$target" ${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}
     DMG_DIRS+=("src-tauri/target/${target}/release/bundle/dmg/")
   fi
 done


### PR DESCRIPTION
Post-v0.2.0 build-tooling fixes, surfaced while cutting the first updater-enabled release.

## `scripts/release.sh` — two latent bugs (only bite the non-`SKIP_UPDATER` path)
1. **`set -u` empty-array crash** — `BUILD_ARGS=()` expanded as `"${BUILD_ARGS[@]}"` aborted with `BUILD_ARGS[@]: unbound variable` before `tauri build` ran. Fixed with the `${arr[@]+"${arr[@]}"}` idiom.
2. **Missing `--config` merge** — without any `--config`, the tauri build-script allowlist check reads only base `tauri.conf.json` (no `macOSPrivateApi`) and rejects the `macos-private-api` feature from the `[target.macos]` block ([tauri#11142](https://github.com/tauri-apps/tauri/issues/11142)). Every `SKIP_UPDATER` build worked only because it passed a `--config`. Now always passes `--config '{"app":{"macOSPrivateApi":true}}'`.

## `docs/BUILD.md` — reconcile to reality
- `release.sh` reads **all** secrets from the **Keychain** (notary password + updater key/password); the old `signing.env` instructions were wrong.
- Document storing the updater key via `$(cat …)` to avoid the trailing-newline corruption that yields `incorrect updater private key password: Invalid input`.
- Note the **rustup** toolchain requirement for Intel cross-compile (Homebrew rust is host-only → `can't find crate for core`).
- Update the auto-update section: it's **live as of v0.2.0** (both Mac arches), not "a later release."

No app-code changes. v0.2.0 is already shipped + live; this makes the next release build cleanly with no manual signing step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)