### PR TITLE
feat(agents): "Needs attention" filter in the Agents pane

### DIFF
--- a/src/lib/components/AgencyDashboard.svelte
+++ b/src/lib/components/AgencyDashboard.svelte
@@ -39,11 +39,11 @@
     return c;
   });
   const healthSegments = $derived([
-    { label: "In sync",   value: byState.current,  color: "var(--color-success)", onClick: () => ui.openAgents() },
-    { label: "Outdated",  value: byState.outdated,  color: "var(--color-warning)", onClick: () => ui.openAgents() },
-    { label: "Modified",  value: byState.modified,  color: "color-mix(in srgb, var(--color-warning) 55%, var(--color-danger))", onClick: () => ui.openAgents() },
-    { label: "Untracked", value: byState.foreign,   color: "var(--color-brand)",   onClick: () => ui.openAgents() },
-    { label: "Missing",   value: byState.removed,   color: "var(--color-danger)",  onClick: () => ui.openAgents() },
+    { label: "In sync",   value: byState.current,  color: "var(--color-success)", onClick: () => ui.openAgents(null, "current") },
+    { label: "Outdated",  value: byState.outdated,  color: "var(--color-warning)", onClick: () => ui.openAgents(null, "outdated") },
+    { label: "Modified",  value: byState.modified,  color: "color-mix(in srgb, var(--color-warning) 55%, var(--color-danger))", onClick: () => ui.openAgents(null, "outdated") },
+    { label: "Untracked", value: byState.foreign,   color: "var(--color-brand)",   onClick: () => ui.openAgents(null, "foreign") },
+    { label: "Missing",   value: byState.removed,   color: "var(--color-danger)",  onClick: () => ui.openAgents(null, "removed") },
   ]);
 
   // ── Coverage by tool — only tools that actually hold agents (less noise) ──
@@ -131,13 +131,13 @@
       <span class="s-lbl">installed by you</span>
     </button>
     {#if attention > 0}
-      <button class="stat warn" onclick={() => ui.openAgents()}>
+      <button class="stat warn" onclick={() => ui.openAgents(null, "attention")}>
         <span class="s-num">{attention}</span>
         <span class="s-lbl">need attention</span>
       </button>
     {/if}
     {#if foreign > 0}
-      <button class="stat info" onclick={() => ui.openAgents()}>
+      <button class="stat info" onclick={() => ui.openAgents(null, "foreign")}>
         <span class="s-num">{foreign}</span>
         <span class="s-lbl">found to track</span>
       </button>

--- a/src/lib/components/AgentsWorkspace.svelte
+++ b/src/lib/components/AgentsWorkspace.svelte
@@ -96,20 +96,14 @@
   // same dot tones shown per row). Local + localStorage like the Tools lens —
   // not nav state. An agent matches a bucket if ANY of its install rows is in
   // it; "none" = no install rows anywhere.
-  type Lens = "all" | "current" | "outdated" | "foreign" | "removed" | "none";
-  const LENS_KEY = "agency-agents:agents-lens";
-  const LENS_IDS: Lens[] = ["all", "current", "outdated", "foreign", "removed", "none"];
-  let lens = $state<Lens>("all");
-  function setLens(l: Lens) {
-    lens = l;
-    try { localStorage.setItem(LENS_KEY, l); } catch { /* private mode / quota */ }
-  }
-  onMount(() => {
-    try {
-      const v = localStorage.getItem(LENS_KEY);
-      if (v && (LENS_IDS as string[]).includes(v)) lens = v as Lens;
-    } catch { /* ignore */ }
-  });
+  type Lens = "all" | "attention" | "current" | "outdated" | "foreign" | "removed" | "none";
+  // The lens lives in nav (ui.agentsLens) — the single source of truth — so the
+  // Dashboard can deep-link a filter ("5 need attention" → the flat attention list)
+  // and back/forward restores it. It no longer persists across launches: a sticky
+  // filter would hijack the divisions landing, since an active lens now switches the
+  // list to a flat all-divisions view (see showDivisions).
+  const lens: Lens = $derived(ui.agentsLens as Lens);
+  function setLens(l: Lens) { ui.setAgentsLens(l); }
 
   /** Which state buckets an agent falls into, across all its install rows. */
   function buckets(slug: string): Set<Lens> {
@@ -118,9 +112,9 @@
     if (rows.length === 0) { s.add("none"); return s; }
     for (const r of rows) {
       if (r.state === "current") s.add("current");
-      else if (r.state === "outdated" || r.state === "modified") s.add("outdated");
+      else if (r.state === "outdated" || r.state === "modified") { s.add("outdated"); s.add("attention"); }
       else if (r.state === "foreign") s.add("foreign");
-      else if (r.state === "removed") s.add("removed");
+      else if (r.state === "removed") { s.add("removed"); s.add("attention"); }
     }
     return s;
   }
@@ -131,7 +125,7 @@
   const visible = $derived(lens === "all" ? base : base.filter((a) => buckets(a.slug).has(lens)));
 
   const lensCounts = $derived.by<Record<Lens, number>>(() => {
-    const c: Record<Lens, number> = { all: base.length, current: 0, outdated: 0, foreign: 0, removed: 0, none: 0 };
+    const c: Record<Lens, number> = { all: base.length, attention: 0, current: 0, outdated: 0, foreign: 0, removed: 0, none: 0 };
     for (const a of base) for (const b of buckets(a.slug)) c[b]++;
     return c;
   });
@@ -139,6 +133,7 @@
   // Lens definitions paired with the row dot tones so the color story matches.
   const LENSES: { id: Lens; label: string; tone: string }[] = [
     { id: "all", label: "All", tone: "" },
+    { id: "attention", label: "Needs attention", tone: "warn" },
     { id: "current", label: "In sync", tone: "ok" },
     { id: "outdated", label: "Outdated", tone: "warn" },
     { id: "foreign", label: "Untracked", tone: "info" },
@@ -167,7 +162,7 @@
   // The Agents tab LANDS on the division list (not a flat agent list): only when
   // no division is drilled into AND there's no active search. Picking a division
   // or typing a query switches to the agent list below.
-  const showDivisions = $derived(ui.agentsCategory === null && !query.trim());
+  const showDivisions = $derived(ui.agentsCategory === null && !query.trim() && lens === "all");
   // Leaving the landing for the agent list shouldn't carry a stale agent-select
   // session; entering it shouldn't either (the landing has its own selection).
   $effect(() => {

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -11,6 +11,7 @@ import type { SettingsSection, SidebarSection, ThemePreference, Tool } from "$li
 interface NavLocation {
   section: SidebarSection;
   agentsCategory: string | null;
+  agentsLens: string;
   agentsSelected: string | null;
   projectsSelected: string | null;
   teamsSelected: string | null;
@@ -131,6 +132,10 @@ class UiStore {
       Lifted into ui so division pills can deep-link to it and so back/forward
       can restore it. */
   agentsCategory: string | null = $state(null);
+  /** Install-state lens for the Agents workspace ("all" | "attention" | "current"
+      | "outdated" | "foreign" | "removed" | "none"). In ui so the Dashboard can
+      deep-link a filter and back/forward can restore it. */
+  agentsLens: string = $state("all");
   /** Slug of the agent open in the workspace detail pane; null = none. In ui so
       back/forward can restore the open agent. */
   agentsSelected: string | null = $state(null);
@@ -216,9 +221,10 @@ class UiStore {
   /** Jump to the unified Agents workspace (optionally within a category);
       resets the open agent. Used by the sidebar, the Dashboard stat cards, and
       the command palette. */
-  openAgents(category: string | null = null) {
+  openAgents(category: string | null = null, lens: string = "all") {
     this.applyingNav = true;
     this.agentsCategory = category;
+    this.agentsLens = lens;
     this.agentsSelected = null;
     this.section = "personas";
     this.selectedPackage = null;
@@ -244,6 +250,7 @@ class UiStore {
   }
 
   setAgentsCategory(c: string | null) { this.agentsCategory = c; this.commitNav(); }
+  setAgentsLens(l: string) { this.agentsLens = l; this.commitNav(); }
   selectAgent(slug: string | null) { this.agentsSelected = slug; this.commitNav(); }
 
   /** Seed history with the current location — call once at startup, after the
@@ -267,6 +274,7 @@ class UiStore {
     return {
       section: this.section,
       agentsCategory: this.agentsCategory,
+      agentsLens: this.agentsLens,
       agentsSelected: this.agentsSelected,
       projectsSelected: this.projectsSelected,
       teamsSelected: this.teamsSelected,
@@ -282,6 +290,7 @@ class UiStore {
       cur &&
       cur.section === loc.section &&
       cur.agentsCategory === loc.agentsCategory &&
+      cur.agentsLens === loc.agentsLens &&
       cur.agentsSelected === loc.agentsSelected &&
       cur.projectsSelected === loc.projectsSelected &&
       cur.teamsSelected === loc.teamsSelected
@@ -297,6 +306,7 @@ class UiStore {
     this.applyingNav = true;
     this.section = loc.section;
     this.agentsCategory = loc.agentsCategory;
+    this.agentsLens = loc.agentsLens;
     this.agentsSelected = loc.agentsSelected;
     this.projectsSelected = loc.projectsSelected;
     this.teamsSelected = loc.teamsSelected;


### PR DESCRIPTION
## Problem
After updating the app, the Dashboard showed *"5 agents need attention"* — but there was no way to see **only** those. The install-state lens existed, but:
- it was **hidden on the divisions landing** (only appeared after drilling into a division),
- it was **scoped to the current division** (agents needing attention in different divisions never showed together), and
- every Dashboard stat — including "N need attention" — called `ui.openAgents()` with **no filter**, dumping you back on the divisions grid.

## Fix
- **New "Needs attention" lens** = Outdated ∪ Modified ∪ Missing (exactly the Dashboard's `attention` definition).
- **Lens moved into nav** (`ui.agentsLens`) → deep-linkable + back/forward-safe. The Dashboard "N need attention" stat, the health-donut segments (Outdated/Modified/Missing/Untracked/In-sync), and "found to track" now **deep-link** to the matching filtered view.
- **Flat across all divisions when a lens is active** (`showDivisions` gates on `lens === "all"`), so scattered drifted agents appear together.
- **Dropped the lens's cross-launch `localStorage` persistence** — now that a lens switches the list off the divisions landing, a sticky filter would hijack the landing on next launch. Each launch opens clean on the landing; filters are set live or via the Dashboard.

Net: click **"5 need attention"** → land on a flat list of exactly those 5, still switchable/clearable, regardless of division.

## Files
`src/lib/stores/ui.svelte.ts` (nav `agentsLens` + `openAgents(category, lens)` + `setAgentsLens`), `src/lib/components/AgentsWorkspace.svelte` (attention bucket, nav-driven lens, flat-list gating), `src/lib/components/AgencyDashboard.svelte` (deep-links).

Frontend only. `svelte-check` 0, `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)