### PR TITLE
docs(memory-bank): v0.2.0 ship + Needs-attention filter

### DIFF
--- a/memory-bank/NEXT-SESSION.md
+++ b/memory-bank/NEXT-SESSION.md
@@ -3,14 +3,19 @@
 Read this first after a compaction. Then `activeContext.md`, `agentLog.md` (append-only history),
 `phases/phase-roadmap.md`, `contracts.md`, `systemPatterns.md`, `decisions.md`.
 
-## ⏩ CURRENT (2026-06-22) — read `activeContext.md` for the live picture
-v0.1.0 SHIPPED (2026-06-16, public/signed/brew). Since then: **v0.1.1** (IA re-org — divisions landing, Teams,
-Projects pillar, the single InstallModal grid + DeployBrowser) and **v0.1.2** (`main` @ `1df932c`, PRs #18+#19):
-the **tool registry single-source** arc — `Tool` enum gone, one upstream-owned `tools.json` (twin of
-`divisions.json`), installability derived from `format ∈ IMPLEMENTED_FORMATS`, all 13 tools, **Osaurus wired**
-(`skill-md`), in-app Playbook, Teams/Projects master-detail, Projects dashboard sunburst. Much below predates
-v0.1.0 (counts/paths may be stale) — `activeContext.md` + `agentLog.md` are authoritative. **NEXT: release prep
-for v0.1.2** (version bump + notes + README Loadouts→Teams).
+## ⏩ CURRENT (2026-06-23) — read `activeContext.md` for the live picture
+**v0.2.0 SHIPPED** (`main` @ `16182e5`, PRs #21 + #22) — first feature release since v0.1.0, rolling up the
+v0.1.1 IA re-org (divisions landing, Teams, Projects pillar, the single InstallModal grid + DeployBrowser) and
+v0.1.2 tool-registry/Osaurus/Playbook arc, **plus LIVE auto-update**. 9 release assets across macOS (aarch64+x64,
+signed/notarized) / Linux (deb/rpm/AppImage) / Windows (x64/arm64); Homebrew cask @ 0.2.0. Auto-update is live at
+`agencyagents.app/updater.json` for **both Mac arches** — dedicated agency signing key `ABF5AFD8` (private key +
+password in the macOS **Keychain**; canonical backup `~/.config/agency-agents-app/updater.key`).
+**Release-build gotchas (hard-won, now in `BUILD.md` + `release.sh`):** updater-on macOS builds must pass a
+`--config` (the macos-private-api allowlist reads only base `tauri.conf.json` — tauri#11142); Intel cross-compile
+needs the **rustup** toolchain (Homebrew rust is host-only); store the updater Keychain key via `$(cat …)` not a
+paste; v0.2.0 asset names use **underscores**. Much further below predates v0.1.0 (counts/paths may be stale) —
+`activeContext.md` + `agentLog.md` (2026-06-23) are authoritative. **NEXT: opt-in automatic install** (wire the
+inert toggle) + the rest of the post-0.2.0 punch list in `docs/PLAN.md`.
 
 ## ✅ THE RE-ORG LANDED (verified 2026-06-14)
 The catalog re-org happened: the active clone now indexes **232 agents** (was ~222). The parity test

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,14 +1,41 @@
 # Active Context — Agency Agents
 
-**State**: 🚀 **v0.1.0 SHIPPED (2026-06-16)** — public release at
-[releases/tag/v0.1.0](https://github.com/msitarzewski/agency-agents-app/releases/tag/v0.1.0): 7 artifacts
-(macOS aarch64+x64 signed/notarized DMGs, Linux deb/rpm/AppImage, Windows x64/arm64). **Repo is now PUBLIC.**
-Site: [agencyagents.app](https://agencyagents.app). Homebrew: `brew tap msitarzewski/agency-agents && brew install --cask agency-agents`.
-Cross-platform CI in `.github/workflows/` (linux-build, windows-build) fires on `v*` tags. macOS DMGs build
-locally via `scripts/release.sh` (mind the beta-toolchain `MACOSX_DEPLOYMENT_TARGET` gotcha — `docs/BUILD.md`).
-Now on **v0.1.2 dev** (`main` @ `1df932c`, PRs #18 + #19 merged). Full launch log: `agentLog.md` 2026-06-16.
+**State**: 🚀 **v0.2.0 SHIPPED (2026-06-23)** — `main` @ `16182e5`. First feature release since the v0.1.0
+launch (the internally-tracked "0.1.1"/"0.1.2" milestones were never cut separately — they ship here), and
+**auto-update is now LIVE** at [`agencyagents.app/updater.json`](https://agencyagents.app/updater.json) for
+**both Mac arches** (`darwin-aarch64` + `darwin-x86_64`). Release at
+[releases/tag/v0.2.0](https://github.com/msitarzewski/agency-agents-app/releases/tag/v0.2.0): **9 assets** (macOS
+aarch64+x64 signed/notarized DMGs **+ updater tarballs**, Linux deb/rpm/AppImage, Windows x64/arm64). Homebrew:
+`brew tap msitarzewski/agency-agents && brew install --cask agency-agents` (cask @ 0.2.0). Cross-platform CI in
+`.github/workflows/` (linux-build, windows-build) fires on `v*` tags; macOS DMGs build locally via
+`scripts/release.sh`. Full ship log: `agentLog.md` 2026-06-23; task doc `tasks/2026-06/260623_v0.2.0-ship.md`.
 
 **Workflow (from 2026-06-16):** ALL changes go through a **branch → PR → merge to `main`**. No direct commits to main.
+
+## ✅ v0.2.0 — first feature release + LIVE auto-update — SHIPPED (2026-06-23, PRs #21 + #22; `main` @ 16182e5)
+- **Auto-update is on.** Endpoint `agencyagents.app/updater.json` (Caddy on `umacbookpro` from `~/Sites/agency-agents/`,
+  sibling vhost to the live `brew-browser.zerologic.com` manifest). **Dedicated agency signing key `ABF5AFD8`**
+  (embedded pubkey in `tauri.conf.json`; private key + password in the **macOS Keychain**, services
+  `agency-agents-updater-key` / `…-key-pw`; canonical key file backup at `~/.config/agency-agents-app/updater.key`).
+  Live path = check → notify → one-click install; full hands-off auto-install is still deferred (the
+  "Install updates automatically" toggle ships **present-but-disabled**).
+- **Release build gotchas (now fixed + documented in `BUILD.md` / `release.sh` / PR #22):**
+  - Updater-on macOS builds **must pass a `--config`** flag — the macos-private-api allowlist check reads only
+    base `tauri.conf.json`, so the split `tauri.macos.conf.json` (`macOSPrivateApi:true`) is invisible to it
+    (tauri#11142). `release.sh` now always passes `--config '{"app":{"macOSPrivateApi":true}}'`. (Every old
+    `SKIP_UPDATER` build worked only because it happened to pass a `--config`.)
+  - **Intel cross-compile needs the rustup toolchain** — Homebrew's `rust` is host-only (`can't find crate for
+    core`). Build with `PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"`.
+  - **Store the updater Keychain key via `$(cat …)`**, never a manual paste — a trailing newline corrupts it and
+    signing fails with `incorrect updater private key password: Invalid input`.
+- **Asset naming uses underscores** (`Agency_Agents_0.2.0_*`), NOT v0.1.0's auto-sanitized dots — the live updater
+  manifest and the brew cask url both depend on this.
+- **Post-ship UX (PR #23):** the Agents pane now has a **"Needs attention" filter** (= Outdated ∪ Modified ∪
+  Missing). The install-state lens moved into nav (`ui.agentsLens`) so the Dashboard "N need attention" stat +
+  health-donut segments **deep-link** to a **flat all-divisions** filtered list (`showDivisions` gates on
+  `lens === "all"`); cross-launch lens persistence dropped (would hijack the landing).
+- Decisions: `decisions.md` 2026-06-22 (host + dedicated key) and 2026-06-23 (build mechanics). Gates: cargo 264/0,
+  svelte-check 0, signed+notarized, CI green.
 
 ## ✅ v0.1.2 — Tool registry + Osaurus + Playbook + Projects dashboard — SHIPPED (2026-06-21, PRs #18 + #19; `main` @ 1df932c)
 **Tool knowledge is now a single source of truth.** It consolidated to the single canonical `tools.json` the
@@ -56,9 +83,9 @@ The whole "how people think about agents" reorganization landed:
 
 **Four-pillar model (drives IA copy):** Agents = *who* · Tools = *how* · Teams = *which* · Projects = *where*.
 
-## 🔵 Backlog (next)
-- **Release prep** for v0.1.2: version bump + release notes + README features pass ("Loadouts" → Teams; mention
-  the tool registry / 13 tools / Osaurus).
+## 🔵 Backlog (next — full list in `docs/PLAN.md` post-0.2.0 punch list)
+- **Opt-in automatic install** — the v0.2.0 "Install updates automatically" toggle is inert; wire it to a real
+  off-by-default background download → verify → install (live updater is check → notify → one-click install today).
 - **Refresh `tools.json` from the catalog clone** (vs. the bundled baseline) — like the corpus + `divisions.json`;
   cleaner now that aa #605 prunes stale convert output.
 - **Foreign-sweep for nested skill dirs** (`…/<dir>/SKILL.md`) so CLI-installed Osaurus/Antigravity skills are
@@ -75,7 +102,7 @@ auto-driven), a `?shim=1` Tauri-IPC shim is temporarily injected into `src/app.h
 ships. The shim can't open a real native folder dialog (returns a fixture path), so "Add project…" looks broken
 in the shim though it works natively.
 
-**Last updated**: 2026-06-22
+**Last updated**: 2026-06-23
 
 ## ✅ Pre-release polish (2026-06-15) — committed + pushed on `release-planning`
 - **brew vestige cleanup**: error-type rename (`BrewError*`→`AppError*`), removed dead `catalogAutoRefresh`

--- a/memory-bank/agentLog.md
+++ b/memory-bank/agentLog.md
@@ -669,3 +669,43 @@ Two PRs merged (`main` @ `1df932c`):
 - Decisions recorded in `decisions.md` (registry single-source / Tool=string · `tools.json` upstream-owned +
   derived installability · contribute transforms upstream first). Task doc:
   `tasks/2026-06/260621_tool-registry-12-tools-osaurus.md`.
+
+## 2026-06-23 — v0.2.0 SHIPPED: first feature release + LIVE auto-update (cross-platform, both Mac arches)
+Cut **v0.2.0** — the first release since the v0.1.0 launch. The manifests still said `0.1.0` and the only tag
+was `v0.1.0`, so the internally-tracked "0.1.1"/"0.1.2" milestones (IA re-org + registry/Osaurus/Playbook) were
+never separate releases; they ship here. Then took it further: **turned auto-update on for real.**
+- **Release prep (PR #21, merged):** version 0.1.0→0.2.0 (`package.json`+`tauri.conf.json`+`Cargo.toml`+`Cargo.lock`);
+  consolidated `docs/release-notes/0.2.0.md`; README four-pillar/Teams/Projects/registry/Osaurus pass (+ Osaurus
+  install-target row, 8 installable); `docs/PLAN.md` refresh (Phase D = done via the registry; post-0.2.0 punch
+  list). Inert "Install updates automatically" toggle (present-but-disabled). Fixed two stale updater strings
+  (`agency-agents-app.zerologic.com` → `agencyagents.app`; broken release-notes URL). **Dedicated agency signing
+  key `ABF5AFD8`** swapped in (clean isolation while no clients live). Scoped review (Code Reviewer + Accessibility)
+  caught a stale Rust `UPDATER_PUBKEY` const → synced. Updater-host ADR resolved (`decisions.md` 2026-06-22).
+- **Auto-update LIVE** at `agencyagents.app/updater.json` (Caddy on umbp from `~/Sites/agency-agents/`, sibling
+  vhost to the proven `brew-browser.zerologic.com` manifest). Building + deploying it surfaced real bugs, all
+  fixed (PR #22):
+  - `release.sh` **`set -u` empty-array crash** (`BUILD_ARGS`) + **missing `--config` merge** — the
+    macos-private-api allowlist check reads only base `tauri.conf.json` ([tauri#11142](https://github.com/tauri-apps/tauri/issues/11142)),
+    so the split `tauri.macos.conf.json` (`macOSPrivateApi:true`) was invisible → updater-on builds failed where
+    every `SKIP_UPDATER` build (which passes a `--config`) succeeded. Now always pass `--config '{"app":{"macOSPrivateApi":true}}'`.
+  - **Intel cross-compile:** active `rustc` is Homebrew's (host-only) → `can't find crate for core`. Build via the
+    **rustup** toolchain (`PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"`); `rustup target
+    add x86_64-apple-darwin` (force remove+add — the component was stale).
+  - **Updater Keychain key corrupted** (trailing-newline paste) → build-time signing `incorrect updater private
+    key password: Invalid input`. The *password* was fine (file-key + Keychain-password signs). Repaired by
+    re-storing the key from the canonical file via `$(cat ~/.config/agency-agents-app/updater.key)`. BUILD.md
+    reconciled to the **Keychain-based** flow `release.sh` actually uses (no `signing.env`).
+- **Shipped — GitHub release v0.2.0, 9 assets:** macOS `aarch64` + `x64` DMGs (signed/notarized) + both updater
+  tarballs (+`.sig`); Linux `deb`/`rpm`/`AppImage` + Windows `x64`/`arm64` NSIS (from the **tag-triggered CI**
+  workflows `linux-build.yml`/`windows-build.yml`). Live manifest covers `darwin-aarch64` **and** `darwin-x86_64`.
+  Homebrew cask bumped to 0.2.0 (`homebrew-agency-agents` @ ed5d283; url pattern dots→underscores + new sha256).
+- PRs **#21** (release) + **#22** (build-tooling/Keychain docs) merged; `main` @ `16182e5`. Asset naming for v0.2.0
+  uses **underscores** (`Agency_Agents_0.2.0_*`), not v0.1.0's auto-sanitized dots — the live updater manifest and
+  the brew cask both depend on this. Task doc: `tasks/2026-06/260623_v0.2.0-ship.md`.
+- **Post-ship UX (PR #23):** added a **"Needs attention" filter** to the Agents pane. After an app update the
+  Dashboard reports N agents needing attention, but there was no way to see ONLY those — the install-state lens
+  was hidden on the divisions landing and scoped to one division. The lens now lives in nav (`ui.agentsLens`,
+  deep-linkable + back/forward-safe); the Dashboard "N need attention" stat + health-donut segments deep-link to
+  the matching filtered view; an active lens shows a **flat all-divisions list** (`showDivisions` gates on
+  `lens === "all"`). New "Needs attention" bucket = Outdated ∪ Modified ∪ Missing. Dropped the lens's cross-launch
+  localStorage persistence (a sticky filter would hijack the landing). svelte-check 0, build clean.

--- a/memory-bank/decisions.md
+++ b/memory-bank/decisions.md
@@ -190,3 +190,24 @@ state; the format-membership rule is self-maintaining: ship a renderer → add i
 "agency-"`). **Consequences**: one `skill-md` renderer covers Osaurus and any future Agent-Skills tool; the
 parity test keeps the app honest. Antigravity stays app-recognized-only until upstream makes its skill
 deterministic (its `date_added` is non-deterministic, so it can't share `skill-md`).
+
+### 2026-06-23: Updater-enabled macOS release build mechanics
+**Status**: Approved (v0.2.0 — the first release built WITHOUT `SKIP_UPDATER`). **Context**: turning auto-update
+on exposed three latent traps that the manual-DMG (`SKIP_UPDATER`) path had always sidestepped. **Decisions**
+(codified in `scripts/release.sh` + `docs/BUILD.md`, PR #22):
+1. **Always pass a `--config` to the macOS build.** The tauri build-script's `macos-private-api` allowlist check
+   reads **only base `tauri.conf.json`** — it does NOT honor the platform-split `tauri.macos.conf.json` where
+   `macOSPrivateApi:true` lives (tauri#11142, closed "not planned"). With no `--config`, the feature (from the
+   `[target.macos]` Cargo block) looks unauthorized and the build aborts. A `--config` forces a full config
+   re-resolution that merges the platform file. `release.sh` always passes `--config '{"app":{"macOSPrivateApi":true}}'`.
+   *Alternatives rejected*: putting `macOSPrivateApi` in base config (breaks the Linux/Windows allowlist) or the
+   feature in base deps (the revert-before-cross-platform dance — fragile, must not be committed).
+2. **Intel cross-compile via the rustup toolchain, not Homebrew rust.** The active `rustc` is Homebrew's
+   (`/opt/homebrew/…`), host-only → `can't find crate for core` for `x86_64-apple-darwin`. Build with
+   `PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"` after `rustup target add x86_64-apple-darwin`.
+3. **The updater signing key lives in the Keychain; store it via `$(cat keyfile)`, never a manual paste.** A
+   trailing newline corrupts the stored key and signing fails with `incorrect updater private key password:
+   Invalid input`. The canonical key is the file `~/.config/agency-agents-app/updater.key` (its pubkey is embedded);
+   the Keychain copy must match it byte-for-byte. `release.sh` is fully Keychain-based — no `signing.env`.
+**Consequences**: `release.sh` now signs updater artifacts cleanly with no manual `signer sign -f` step; the next
+release "just works." **References**: `tasks/2026-06/260623_v0.2.0-ship.md`, `~/Downloads/fix-updater-keychain.sh`.

--- a/memory-bank/tasks/2026-06/260623_v0.2.0-ship.md
+++ b/memory-bank/tasks/2026-06/260623_v0.2.0-ship.md
@@ -1,0 +1,74 @@
+# 260623_v0.2.0-ship
+
+## Objective
+Cut **v0.2.0** — the first release since the v0.1.0 launch — and turn on **auto-update for real**
+(present-but-disabled since v0.1.0). The repo had never bumped off `0.1.0`, so v0.2.0 rolls up the
+internally-tracked "0.1.1" (IA re-org) and "0.1.2" (tool registry / Osaurus / Playbook) work plus the
+new updater activation, across every platform.
+
+## Outcome
+- ✅ **GitHub release v0.2.0** — 9 assets (both Mac DMGs + updater tarballs, Linux deb/rpm/AppImage,
+  Windows x64/arm64). https://github.com/msitarzewski/agency-agents-app/releases/tag/v0.2.0
+- ✅ **Auto-update LIVE** at `agencyagents.app/updater.json` — covers `darwin-aarch64` **and** `darwin-x86_64`.
+- ✅ **Homebrew** cask bumped to 0.2.0 (`homebrew-agency-agents` @ ed5d283).
+- ✅ PRs **#21** (release prep) + **#22** (build-tooling + Keychain docs) merged; `main` @ `16182e5`.
+- Gates: `cargo test` 264/0, `svelte-check` 0, macOS builds signed + notarized, CI Linux/Windows green.
+
+## What shipped
+### Release prep (PR #21)
+- Version `0.1.0` → `0.2.0` (`package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`); consolidated
+  `docs/release-notes/0.2.0.md`; README four-pillar / Teams / Projects / registry / Osaurus pass (Osaurus added
+  to the install-target table — 8 installable); `docs/PLAN.md` refresh (Phase D done via the registry; a
+  post-0.2.0 punch list).
+- **Dedicated agency signing key** (`ABF5AFD8`) embedded, swapped off the key shared with brew-browser — clean
+  signing isolation, done while no updater client was live (zero continuity cost). Stale Rust `UPDATER_PUBKEY`
+  const synced (caught by a scoped Code-Reviewer pass). Inert "Install updates automatically" toggle added
+  (present-but-disabled; full hands-off auto-install is still future).
+
+### Auto-update activation
+- Endpoint `https://agencyagents.app/updater.json`, served by **Caddy on `umacbookpro`** from `~/Sites/agency-agents/`
+  (the `agencyagents.app` docroot — a sibling vhost to the live `brew-browser.zerologic.com/updater.json`).
+- Flow: `./scripts/release.sh` (no `SKIP_UPDATER`) → `tools/release/publish-manifest.sh` → `gh release create`
+  + `rsync dist/updater.json umacbookpro:Sites/agency-agents/updater.json`. The Intel `darwin-x86_64` manifest
+  entry is added by hand (publish-manifest.sh emits `darwin-aarch64` only).
+
+### Cross-platform parity
+- macOS aarch64 (native) + x64 (cross-compile) built locally, signed + notarized.
+- Linux deb/rpm/AppImage + Windows x64/arm64 from the **tag-triggered CI** (`.github/workflows/linux-build.yml`,
+  `windows-build.yml`) — downloaded with `gh run download` and attached to the release.
+
+## Bugs found + fixed (PR #22) — all only bite the updater-enabled (`--config`-less) build path
+1. **`release.sh` `set -u` empty-array crash** — `BUILD_ARGS=()` expanded as `"${BUILD_ARGS[@]}"` aborted with
+   `BUILD_ARGS[@]: unbound variable`. Fixed with `${arr[@]+"${arr[@]}"}`.
+2. **Missing `--config` merge** — the tauri build-script allowlist check reads only base `tauri.conf.json`
+   ([tauri#11142](https://github.com/tauri-apps/tauri/issues/11142)); the split `tauri.macos.conf.json`
+   (`macOSPrivateApi:true`) is invisible to it, so the `macos-private-api` feature from `[target.macos]` is
+   rejected. Every `SKIP_UPDATER` build worked only because it passed a `--config`. Now always passes
+   `--config '{"app":{"macOSPrivateApi":true}}'`.
+3. **Intel cross-compile** — active `rustc` is Homebrew's (host-only) → `can't find crate for core`. Build via
+   the **rustup** toolchain on PATH; `rustup target add x86_64-apple-darwin` (force remove+add).
+4. **Updater Keychain key corrupted** (trailing-newline paste) → `incorrect updater private key password:
+   Invalid input` at build-time signing. Password was correct; the *key content* in the Keychain had drifted
+   from the canonical file. Repaired by re-storing via `$(cat ~/.config/agency-agents-app/updater.key)`
+   (`~/Downloads/fix-updater-keychain.sh`). `BUILD.md` reconciled to the Keychain-based flow (no `signing.env`).
+
+## Decisions (see decisions.md)
+- **2026-06-22:** Updater host = `agencyagents.app`; dedicated agency signing key (resolves the OPEN host ADR).
+- **2026-06-23:** Updater-enabled macOS release build mechanics (the `--config` allowlist requirement, the
+  rustup-for-Intel requirement, Keychain key-storage via `$(cat …)`).
+
+## Files
+- App/release: `package.json`, `src-tauri/{tauri.conf.json,Cargo.toml,Cargo.lock,src/lib.rs}`,
+  `src/lib/components/{SettingsSectionUpdates,SettingsSectionNetwork}.svelte`, `src/lib/types.ts`,
+  `docs/release-notes/0.2.0.md`, `README.md`, `docs/PLAN.md`.
+- Build tooling: `scripts/release.sh`, `docs/BUILD.md`, `tools/release/publish-manifest.sh`.
+- Other repos (same machine): `homebrew-agency-agents/Casks/agency-agents.rb` (@ ed5d283).
+
+## Artifacts
+- PRs: #21, #22 (this repo). Tag `v0.2.0`. Release: 9 assets. Cask: `homebrew-agency-agents` @ ed5d283.
+
+## Deferred (post-0.2.0 punch list — `docs/PLAN.md`)
+- Opt-in **automatic install** (the inert toggle → real off-by-default background install).
+- Refresh `tools.json` from the catalog clone; Foreign-sweep for nested skill dirs.
+- Antigravity (blocked upstream on non-deterministic `date_added`); multi-file renderers (Aider/Windsurf/OpenClaw/Kimi).
+- Windows code signing; local-runtime target (Ollama/LM Studio).

--- a/memory-bank/tasks/2026-06/README.md
+++ b/memory-bank/tasks/2026-06/README.md
@@ -60,8 +60,19 @@ enum dropped; installability derived from `format ∈ IMPLEMENTED_FORMATS`). All
 In-app Playbook + `docs/USING-AGENTS.md`; Teams/Projects master-detail; Global-vs-Projects dashboard sunburst.
 cargo 264/0, svelte-check 0. See [260621_tool-registry-12-tools-osaurus.md](./260621_tool-registry-12-tools-osaurus.md).
 
+### 2026-06-23: v0.2.0 SHIPPED — first feature release + LIVE auto-update (cross-platform) (PRs #21 + #22)
+First release since v0.1.0 (the "0.1.1"/"0.1.2" milestones were never cut separately — they ship here), and
+**auto-update is now live** at `agencyagents.app/updater.json` for both Mac arches. 9 assets (macOS aarch64+x64
+DMGs + updater tarballs, Linux deb/rpm/AppImage, Windows x64/arm64); Homebrew cask bumped to 0.2.0. Dedicated
+agency signing key (`ABF5AFD8`). Shook out two real `release.sh` bugs (`set -u` empty-array + missing `--config`
+allowlist merge / tauri#11142), the rustup-vs-Homebrew Intel cross-compile split, and a corrupted updater
+Keychain key — all fixed + documented (`BUILD.md` reconciled to the Keychain flow). `main` @ `16182e5`.
+See [260623_v0.2.0-ship.md](./260623_v0.2.0-ship.md).
+
 ## Next
-- **Release prep** for v0.1.2: version bump + release notes + README "Loadouts" → Teams.
+- **Opt-in automatic install** — wire the inert "Install updates automatically" toggle to a real off-by-default
+  background download → verify → install (the live updater currently does check → notify → one-click install).
 - Refresh `tools.json` from the catalog clone; Foreign-sweep for nested skill dirs; Antigravity once its skill is
-  deterministic (`date_added` dropped).
-- Deferred: local-runtime system-prompt target (Ollama/LM Studio).
+  deterministic (`date_added` dropped); multi-file renderers (Aider/Windsurf/OpenClaw/Kimi).
+- Windows code signing; local-runtime system-prompt target (Ollama/LM Studio).
+- See the full post-0.2.0 punch list in `docs/PLAN.md`.


### PR DESCRIPTION
Brings the memory bank current — it still pointed at "release prep for v0.1.2".

- **agentLog.md** — 2026-06-23 entry: v0.2.0 SHIPPED (first feature release + live auto-update, both Mac arches), the four real build bugs + fixes, and the post-ship "Needs attention" filter (PR #23).
- **activeContext.md** — new v0.2.0 header + section (live auto-update, dedicated signing key, build gotchas), fixed the stale "v0.1.2 release prep" backlog, added the filter note.
- **NEXT-SESSION.md** — rewrote the CURRENT resume pointer.
- **decisions.md** — new ADR: updater-enabled macOS build mechanics (`--config`/tauri#11142, rustup-for-Intel, Keychain key-storage via `$(cat …)`).
- **tasks/2026-06/README.md** — v0.2.0 ship entry + rewritten Next.
- **tasks/2026-06/260623_v0.2.0-ship.md** — new full task doc.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)