### PR TITLE
fix(reconcile): honest install counts (Total Installed + tracked split)

### DIFF
--- a/src-tauri/src/install/mod.rs
+++ b/src-tauri/src/install/mod.rs
@@ -668,6 +668,7 @@ pub async fn installs_reconcile(
             dest: r.dest.clone(),
             state: st,
             update_kind,
+            tracked: true,
         });
     }
 
@@ -691,29 +692,48 @@ pub async fn installs_reconcile(
         .collect();
     let home = home()?;
     for tool in supported() {
+        // Some tools namespace the output slug (e.g. Osaurus dirs are
+        // `agency-<slug>`); strip it before recognizing the agent.
+        let prefix = crate::registry::get(tool)
+            .and_then(|m| m.slug_prefix.as_deref())
+            .unwrap_or("");
         // Dual-scope tools are scanned in BOTH places: the user-global dir (key
         // None) AND every project root the ledger knows about (key Some(path)).
-        let mut scan_roots: Vec<(Option<String>, PathBuf)> = Vec::new();
+        // Each entry: (scope-key, agents-root, suffix-after-`{slug}`).
+        let mut scan_roots: Vec<(Option<String>, PathBuf, String)> = Vec::new();
         if render::supports_user(tool) {
-            scan_roots.extend(agent_dirs(tool, &home, None).into_iter().map(|d| (None, d)));
+            scan_roots
+                .extend(agent_units(tool, &home, None).into_iter().map(|(d, s)| (None, d, s)));
         }
         if render::supports_project(tool) {
             scan_roots.extend(project_dirs.iter().flat_map(|p| {
                 let key = Some(p.to_string_lossy().to_string());
-                agent_dirs(tool, &home, Some(p)).into_iter().map(move |d| (key.clone(), d))
+                agent_units(tool, &home, Some(p)).into_iter().map(move |(d, s)| (key.clone(), d, s))
             }));
         }
-        for (proj, dir) in scan_roots {
-            let mut rd = match tokio::fs::read_dir(&dir).await {
+        for (proj, agents_root, suffix) in scan_roots {
+            let mut rd = match tokio::fs::read_dir(&agents_root).await {
                 Ok(r) => r,
                 Err(_) => continue,
             };
+            // A leading `/` in the suffix means the per-agent unit is a DIRECTORY
+            // (e.g. `{slug}/SKILL.md`); otherwise it's a file (`{slug}.md`).
+            let dir_unit = suffix.starts_with('/');
             while let Ok(Some(ent)) = rd.next_entry().await {
-                let path = ent.path();
-                let Some(file_slug) = path.file_stem().and_then(|s| s.to_str()) else { continue };
-                let Some(agent) = corpus
-                    .get(file_slug)
-                    .or_else(|| corpus.get_by_conversion_slug(file_slug))
+                let name = ent.file_name();
+                let Some(name) = name.to_str() else { continue };
+                // Recover the `{slug}` token + the file that holds the canonical
+                // bytes. Dir unit: the entry IS the slug dir, bytes at <dir>/<leaf>.
+                // File unit: the entry is `<slug><suffix>`.
+                let (token, byte_path) = if dir_unit {
+                    (name.to_string(), agents_root.join(name).join(suffix.trim_start_matches('/')))
+                } else if name.ends_with(suffix.as_str()) && name.len() > suffix.len() {
+                    (name[..name.len() - suffix.len()].to_string(), agents_root.join(name))
+                } else {
+                    continue; // not a unit for this template (stray file/dir)
+                };
+                let cand = token.strip_prefix(prefix).unwrap_or(&token);
+                let Some(agent) = corpus.get(cand).or_else(|| corpus.get_by_conversion_slug(cand))
                 else {
                     continue; // unrecognized → not ours to claim
                 };
@@ -723,7 +743,7 @@ pub async fn installs_reconcile(
                 }
                 // Byte-identical to the catalog ⇒ in sync ⇒ Current. Otherwise a
                 // recognized-but-divergent file ⇒ Foreign (worth a look).
-                let state = if is_canonical_on_disk(&app, &agent, tool, &path).await {
+                let state = if is_canonical_on_disk(&app, &agent, tool, &byte_path).await {
                     InstallState::Current
                 } else {
                     InstallState::Foreign
@@ -734,9 +754,10 @@ pub async fn installs_reconcile(
                     tool: tool.to_string(),
                     scope: render::scope_for(proj.as_deref().map(std::path::Path::new)),
                     project_path: proj.clone(),
-                    dest: path.to_string_lossy().to_string(),
+                    dest: byte_path.to_string_lossy().to_string(),
                     state,
                     update_kind: None,
+                    tracked: false,
                 });
             }
         }
@@ -752,13 +773,31 @@ pub async fn installs_reconcile(
     Ok(out)
 }
 
-/// The directory/directories a tool writes agent files into (parents of the
-/// per-agent dests). Used by the Foreign sweep.
-fn agent_dirs(tool: &str, home: &Path, project_root: Option<&Path>) -> Vec<PathBuf> {
-    render::dests(tool, "_probe", home, project_root)
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|p| p.parent().map(|d| d.to_path_buf()))
+/// For the Foreign sweep: each scannable agents-root for a tool, paired with the
+/// path suffix that follows `{slug}` in the dest template. The suffix tells the
+/// sweep whether a per-agent UNIT is a file (e.g. `.md`) or a directory (e.g.
+/// `/SKILL.md`), and where the canonical bytes live inside a dir unit.
+///
+/// Splitting the TEMPLATE (not a `{slug}`-substituted path) is what makes
+/// dir-structured tools work: Osaurus's `.osaurus/skills/{slug}/SKILL.md` scans
+/// `.osaurus/skills` instead of a bogus `.osaurus/skills/_probe`.
+fn agent_units(tool: &str, home: &Path, project_root: Option<&Path>) -> Vec<(PathBuf, String)> {
+    let Some(meta) = crate::registry::get(tool) else {
+        return Vec::new();
+    };
+    let Some(dest) = meta.dest.as_ref() else {
+        return Vec::new();
+    };
+    let (templates, root): (&[String], &Path) = match project_root {
+        Some(p) => (&dest.project, p),
+        None => (&dest.user, home),
+    };
+    templates
+        .iter()
+        .filter_map(|t| {
+            t.split_once("{slug}")
+                .map(|(before, after)| (root.join(before), after.to_string()))
+        })
         .collect::<std::collections::BTreeSet<_>>()
         .into_iter()
         .collect()
@@ -1003,6 +1042,23 @@ mod tests {
         assert_eq!(classify(Some("r"), "r", "s1", Some("s2")), InstallState::Outdated);
         // agent gone from corpus but file intact → current
         assert_eq!(classify(Some("r"), "r", "s1", None), InstallState::Current);
+    }
+
+    #[test]
+    fn agent_units_handles_file_and_dir_tools() {
+        let home = std::path::Path::new("/home/u");
+        // File-per-agent (Claude): root = ~/.claude/agents, suffix = ".md".
+        let claude = agent_units("claudeCode", home, None);
+        assert!(
+            claude.iter().any(|(d, s)| d.ends_with(".claude/agents") && s == ".md"),
+            "claude: {claude:?}"
+        );
+        // Dir-per-agent (Osaurus): the bug was scanning `.osaurus/skills/_probe`.
+        // It must scan `.osaurus/skills` with a `/SKILL.md` leaf.
+        let osa = agent_units("osaurus", home, None);
+        assert_eq!(osa.len(), 1, "osaurus: {osa:?}");
+        assert!(osa[0].0.ends_with(".osaurus/skills"), "osaurus dir: {:?}", osa[0].0);
+        assert_eq!(osa[0].1, "/SKILL.md");
     }
 
     fn sample_agent() -> crate::types::Agent {

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -254,6 +254,11 @@ pub struct InstalledAgent {
     pub dest: String,
     pub state: InstallState,
     pub update_kind: Option<UpdateKind>,
+    /// True when THIS app installed it (it's in the ledger); false when the
+    /// Foreign sweep found it on disk (e.g. a prior `install.sh` run). Lets the
+    /// UI distinguish "tracked by the app" from "present from other tools"
+    /// instead of claiming every recognized file as "installed by you".
+    pub tracked: bool,
 }
 
 /// Result of `agent_diff` — what's on disk now vs the canonical render the app
@@ -371,6 +376,7 @@ mod tests {
             dest: "/Users/x/.claude/agents/frontend-developer.md".into(),
             state: InstallState::Outdated,
             update_kind: Some(UpdateKind::Cosmetic),
+            tracked: true,
         };
         let v = serde_json::to_value(&a).unwrap();
         for k in [

--- a/src/lib/components/AgencyDashboard.svelte
+++ b/src/lib/components/AgencyDashboard.svelte
@@ -158,7 +158,7 @@
         {#if managed === 0}
           <p class="muted">Nothing installed yet — deploy an agent and it'll show up here.</p>
         {:else}
-          <InstallSunburst groups={sunburstGroups} centerLabel={String(managed)} centerSub="installs" />
+          <InstallSunburst groups={sunburstGroups} />
         {/if}
       </div>
     </div>
@@ -207,7 +207,7 @@
         {#if totalInstalls === 0}
           <p class="muted">Nothing installed yet — deploy an agent to see its health here.</p>
         {:else}
-          <HealthDonut segments={healthSegments} centerLabel={String(totalInstalls)} centerSub="installs" />
+          <HealthDonut segments={healthSegments} />
         {/if}
       </div>
     </div>

--- a/src/lib/components/AgencyDashboard.svelte
+++ b/src/lib/components/AgencyDashboard.svelte
@@ -26,6 +26,10 @@
 
   const available = $derived(corpus.agents.length);
   const managed = $derived(install.installed.filter((i) => i.state !== "foreign").length);
+  // Of that present-on-disk total, how many THIS app installed (ledger-tracked)
+  // vs. picked up from elsewhere (a prior CLI `install.sh` run, byte-matched).
+  const trackedByApp = $derived(install.installed.filter((i) => i.tracked && i.state !== "foreign").length);
+  const fromOtherTools = $derived(managed - trackedByApp);
   const attention = $derived(
     install.installed.filter((i) => ["outdated", "modified", "removed"].includes(i.state)).length,
   );
@@ -128,7 +132,10 @@
     </button>
     <button class="stat" onclick={() => ui.openAgents()}>
       <span class="s-num">{managed}</span>
-      <span class="s-lbl">installed by you</span>
+      <span class="s-lbl">Total Installed</span>
+      {#if fromOtherTools > 0}
+        <span class="s-sub">{trackedByApp} via this app · {fromOtherTools} other tools</span>
+      {/if}
     </button>
     {#if attention > 0}
       <button class="stat warn" onclick={() => ui.openAgents(null, "attention")}>
@@ -146,7 +153,7 @@
 
   <div class="cols">
     <div class="card">
-      <h3 class="c-title">Installed by you</h3>
+      <h3 class="c-title">Total Installed</h3>
       <div class="card-fill center">
         {#if managed === 0}
           <p class="muted">Nothing installed yet — deploy an agent and it'll show up here.</p>
@@ -250,6 +257,7 @@
   .stat:hover { border-color: var(--color-brand); }
   .s-num { font-size: 30px; font-weight: var(--fw-bold); color: var(--color-text-primary); line-height: 1; }
   .s-lbl { font-size: var(--text-body-sm); color: var(--color-text-muted); }
+  .s-sub { font-size: 11px; color: var(--color-text-muted); opacity: 0.85; margin-top: 3px; }
   .stat.warn .s-num { color: var(--color-warning); }
   .stat.info .s-num { color: var(--color-info, var(--color-brand)); }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -462,6 +462,10 @@ export interface InstalledAgent {
   dest: string;
   state: InstallState;
   updateKind: UpdateKind | null;
+  /** True when THIS app installed it (it's in the ledger); false when the
+      reconcile found it on disk from another source (e.g. a CLI `install.sh`
+      run). Lets the UI separate "tracked by the app" from "total present". */
+  tracked: boolean;
 }
 
 /** Result of `agent_diff` — current on-disk contents vs the canonical render


### PR DESCRIPTION
The Dashboard claimed **"Installed by you: 246"** when the app's ledger had only **~29** installs — the rest are prior `install.sh` agents the reconcile byte-matches and counts as "in sync." This makes the counts both **truthful** and a bit more robust.

## Fixes
1. **`InstalledAgent.tracked`** — `true` for ledger installs, `false` for foreign-sweep finds. Lets the UI separate "tracked by the app" from "present from other sources."
2. **"Total Installed"** — relabeled from "installed by you" (stat + card heading), with a sub-line **"{N} via this app · {M} other tools."** The number is honest, and the split is explicit.
3. **Foreign-sweep robustness (`agent_units`)** — `agent_dirs()` did a single `.parent()` on the substituted dest, so a dir-structured tool like Osaurus (`.osaurus/skills/{slug}/SKILL.md`) scanned a bogus `~/.osaurus/skills/_probe`. Replaced with `agent_units()`, which splits the dest **template** on `{slug}` to get the real agents-root + suffix, handles **directory units** (byte-checking `<dir>/SKILL.md`), and strips the tool's `slug_prefix` before recognition. Correct for the general case (a future CLI-installed `agency-*` skill not in the ledger would now surface). **Note:** no visible count delta on a machine whose foreign skill dirs dedupe against existing ledger entries — earlier "Osaurus undercount" framing was a misdiagnosis (those `finance-*` dirs were stale duplicates of the same agents, plus an unrelated skill).

## Why it matters
The aa-repo audience already runs `install.sh` across tools — "installed by **you**" reads wrong when most installs came from the CLI. "Total Installed" + the split tells the truth.

`cargo` 266/0, `svelte-check` 0. Part of v0.2.1.