### PR TITLE
fix(nav): Dashboard project click navigates to the project

### DIFF
--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -205,8 +205,10 @@ class UiStore {
   }
 
   /** Open the Projects detail pane for a project path (null = back to the list).
-      A nav location, so the title-bar back button returns to the list. */
-  selectProject(path: string | null) { this.projectsSelected = path; this.selectedPackage = null; this.commitNav(); }
+      A nav location, so the title-bar back button returns to the list. Also
+      switches to the Projects section, so deep-links from the Dashboard
+      ("mirror-mesh" row / sunburst slice) actually land on the project. */
+  selectProject(path: string | null) { this.section = "projects"; this.projectsSelected = path; this.selectedPackage = null; this.commitNav(); }
 
   /** Open the Teams detail pane for a team key (null = back to the list).
       A nav location, so the title-bar back button returns to the list. */


### PR DESCRIPTION
Clicking a project on the Dashboard (the **PROJECTS** card row, e.g. `mirror-mesh`, or a Projects sunburst slice) called `ui.selectProject(path)`, which set `projectsSelected` but **never switched to the Projects section** — so it selected the project invisibly and left you on the Dashboard.

Fix: `selectProject` now also sets `section = "projects"`, so the deep-link lands on the project's detail pane. The other callers are all inside the Projects panel already (section is a no-op there) — including the deselect/toggle path — so this is safe.

svelte-check 0. Small v0.2.1 polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)