### PR TITLE
release: v0.2.1 — honest install counts, installKind/Hermes, project nav

### DIFF
--- a/docs/release-notes/0.2.1.md
+++ b/docs/release-notes/0.2.1.md
@@ -1,0 +1,66 @@
+## Agency Agents v0.2.1 — 2026-06-28
+
+A focused follow-up to v0.2.0. The headline isn't a feature — it's honesty: the dashboard now
+reports install counts you can trust. This is also the **first release delivered through the live
+in-app updater** — v0.2.0 users will be offered this build automatically.
+
+### Downloads
+
+- **macOS** (Apple Silicon & Intel) — signed + notarized `.dmg`, launches without warnings. macOS 13+.
+- **Linux** (x86_64) — `.deb` (Debian/Ubuntu), `.rpm` (Fedora/RHEL/openSUSE), or the portable `.AppImage`.
+- **Windows** (x64 & ARM64) — `.exe` installer. Not code-signed yet, so SmartScreen warns on first launch → click **More info → Run anyway** (see Known Notes).
+
+Or visit [agencyagents.app](https://agencyagents.app). v0.2.0 users: just accept the in-app update prompt.
+
+### Highlights
+
+**Honest install counts:**
+
+- The dashboard's "installed by you" stat was cumulative and misleading — it counted every agent
+  present on disk (including ones placed by older CLI `install.sh` runs that happened to byte-match
+  the catalog) as if the app had installed them. It's now relabeled **"Total Installed"** with a
+  sub-line that splits the number honestly: **"{N} via this app · {M} other tools."**
+- Installed agents now carry a `tracked` flag — true when the app's ledger placed them, false when
+  they were discovered already present by the foreign sweep — so the two populations are never
+  conflated again.
+- Foreign-sweep robustness: directory-based targets (like Osaurus, which writes
+  `~/.osaurus/skills/<slug>/SKILL.md`) and slug-prefixed skills are now scanned at their real
+  destination instead of a derived parent, and the recognized agent is matched after stripping the
+  install prefix.
+- Removed the redundant center number from the **Total Installed** and **Install Health** donuts —
+  the stat row and legend already carry the totals.
+
+**Catalog `installKind` + Hermes:**
+
+- The app now reads the catalog's `installKind` field (`per-agent` / `roster` / `plugin`) as upstream
+  truth. Installability is derived as `installKind != "plugin" && format is implemented`, so a tool
+  whose mechanism the app doesn't drive natively can never be offered as a one-click install.
+- **Hermes** (the lazy router plugin from upstream) is recognized as a `plugin`-kind tool and shown
+  recognized-only. By design the app does **not** shell out to its Python installer — Agency Agents
+  installs personas into tools, it isn't a command-runner. If you use Hermes, install it from the
+  catalog repo directly.
+
+**Dashboard navigation:**
+
+- Clicking a project on the dashboard now navigates into that project instead of staying put.
+
+### Quality Gates
+
+- `cargo test --lib` (266 passing, incl. renderer byte-parity and the new plugin-never-installable + agent-units tests)
+- `npm run check` (0 errors)
+- `npm run build`
+- ignored renderer parity test against the active `agency-agents` clone
+- full cross-platform build matrix (macOS + Ubuntu deb/rpm/appimage + Windows x64/arm64)
+
+### Known Release Notes
+
+- The app is not an agent runtime — it installs personas into other tools; it does not execute them.
+- Recognized-only targets (Antigravity, Aider, Windsurf, OpenClaw, Kimi, and now the Hermes router
+  plugin) appear dimmed; they need additional renderer work — or, for plugin-kind tools, a different
+  install mechanism the app intentionally doesn't drive — before they're exposed as first-class installs.
+- CLI-installed Osaurus skills are not yet auto-detected by Foreign-sweep; app-installed ones are tracked normally.
+- **Windows: the build is not code-signed yet.** On first launch Microsoft Defender SmartScreen will show
+  "Windows protected your PC". To run it: click **More info → Run anyway**.
+- **Auto-update delivers from here forward.** This is the first release the v0.2.0 updater will hand out.
+  v0.1.0 users still upgrade manually (that build predates the live endpoint). Fully hands-off automatic
+  install (the "Install updates automatically" toggle) is present but disabled — opt-in auto-install lands later.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agency-agents-app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Agency Agents — a native macOS app store for AI agents. Browse, install, and track 251+ specialized agents across every AI coding tool.",
   "type": "module",
   "author": "Michael Sitarzewski",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agency-agents-app"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agency-agents-app"
-version = "0.2.0"
+version = "0.2.1"
 description = "Agency Agents — a native macOS app store for AI agents."
 authors = ["Michael Sitarzewski"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Agency Agents",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.zerologic.agency-agents-app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## v0.2.1 release prep

Version bump (0.2.0 → 0.2.1) across `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock` + consolidated release notes (`docs/release-notes/0.2.1.md`).

Rolls up the three features already merged to `main`:

- **#28** — adopt the catalog `installKind` field (`per-agent` / `roster` / `plugin`); recognize the **Hermes** router plugin as recognized-only (the app does not shell out to its installer).
- **#29** — honest dashboard counts: **"Total Installed"** + "via this app · other tools" split + new `tracked` flag; foreign-sweep robustness for directory/prefixed targets; dropped the redundant donut center number.
- **#30** — dashboard project click navigates into the project.

This is the **first release delivered through the live v0.2.0 in-app updater**.

### Quality gates
- `cargo test --lib` — 266 passing
- `npm run check` — 0 errors
- Cargo.toml base deps clean (no `macos-private-api` leak into cross-platform builds)

### Deferred
- `chore/release-asset-naming` (platform infix in asset filenames) — kept out of this cut to avoid simultaneous manifest/cask/CI churn; lands as its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)