### PR TITLE
fix(linux): disable WebKitGTK DMABUF renderer to stop EGL crash (#641)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,17 @@ pub fn updater_pubkey() -> &'static str {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // WebKitGTK's DMABUF renderer aborts with "Could not create default EGL
+    // display: EGL_BAD_PARAMETER" on a lot of Linux GPU/driver stacks (Arch,
+    // NVIDIA, Wayland, newer Mesa) — the webview never comes up (issue #641).
+    // Forcing the non-DMABUF path before GTK/WebKit initializes fixes it, at a
+    // negligible rendering cost. Only touch it when the user hasn't set it
+    // themselves, so an explicit override still wins.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     // Best-effort tracing setup — silent if RUST_LOG is unset.
     let _ = tracing_subscriber::fmt()
         .with_env_filter(


### PR DESCRIPTION
## Problem
`Agency_Agents_0.2.1_amd64.AppImage` aborts on launch with:
```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```
This is WebKitGTK's DMABUF renderer failing to create an EGL display — a well-known issue on many Linux GPU/driver stacks (Arch, NVIDIA, Wayland, newer Mesa). The process dies before the webview appears. Reported in msitarzewski/agency-agents#641 (@tuxarch, Arch).

## Fix
Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` at the very top of `run()` (`src-tauri/src/lib.rs`), before GTK/WebKit initializes — and only when the user hasn't already set the variable, so an explicit override still wins. Linux-only via `#[cfg(target_os = "linux")]`; a no-op on macOS/Windows.

## Testing
- Host (`cargo check` + `cargo test --lib`): clean, 266 pass.
- Linux compile of the `cfg(linux)` block validated via a `workflow_dispatch` Linux CI run on this branch.
- Immediate user workaround while this ships: `WEBKIT_DISABLE_DMABUF_RENDERER=1 ./Agency_Agents_0.2.1_amd64.AppImage`.

Resolves msitarzewski/agency-agents#641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)