### PR TITLE
i18n(tools): translate the per-tool install-location strings

### DIFF
--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -612,6 +612,15 @@ const de = {
   "teamExample.product-discovery.2": "Recherchiere, was Wettbewerber für [problem] liefern, und empfehle, was wir als Nächstes bauen sollten, inklusive Annahmen und Risiken.",
   "teamExample.ai-builders.1": "Entwirf und baue [AI feature] auf einer soliden Daten- und Prompt-Grundlage: Schema, Retrieval, Prompts und Evals; iteriere, bis die Evals auf einem Holdout-Set bestehen.",
   "teamExample.ai-builders.2": "Härte unsere Prompts für [use case]: schreibe Testfälle, miss die Erfolgsrate und iteriere, bis sie zuverlässig sind.",
+  "tools.location": "Speicherort",
+  "tools.locationTitle": "Benutzerdefinierten Installationsort für {tool} festlegen",
+  "tools.customLocation": "benutzerdefinierter Ort",
+  "tools.installLocation": "Installationsort",
+  "tools.locationDefault": "Standard (~)",
+  "tools.locationDefaultTitle": "Standard (Home-Verzeichnis)",
+  "tools.locationHint": "Richten Sie {tool} auf ein benutzerdefiniertes Basisverzeichnis aus — z. B. ein WSL-Home ({wsl}) aus der Windows-App. Erkennung und benutzerglobale Installationen folgen ihm; Projektinstallationen sind nicht betroffen.",
+  "tools.locationChoose": "Ordner wählen…",
+  "tools.locationReset": "Auf Standard zurücksetzen",
 } satisfies Partial<Messages>;
 
 export default de;

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -612,6 +612,15 @@ const es = {
   "teamExample.product-discovery.2": "Investiga qué envían los competidores para [problem] y recomienda qué construir después, con supuestos y riesgos explícitos.",
   "teamExample.ai-builders.1": "Diseña y construye [AI feature] sobre una base sólida de datos y prompts: schema, retrieval, prompts y evals; itera hasta que las evals pasen en un set reservado.",
   "teamExample.ai-builders.2": "Endurece nuestros prompts para [use case]: escribe casos de prueba, mide la tasa de aprobación e itera hasta que sea fiable.",
+  "tools.location": "Ubicación",
+  "tools.locationTitle": "Establecer una ubicación de instalación personalizada para {tool}",
+  "tools.customLocation": "ubicación personalizada",
+  "tools.installLocation": "Ubicación de instalación",
+  "tools.locationDefault": "Predeterminada (~)",
+  "tools.locationDefaultTitle": "Predeterminada (directorio de inicio)",
+  "tools.locationHint": "Apunta {tool} a un directorio base personalizado — por ejemplo, un directorio de inicio de WSL ({wsl}) desde la app de Windows. La detección y las instalaciones globales de usuario lo siguen; las instalaciones de proyecto no se ven afectadas.",
+  "tools.locationChoose": "Elegir carpeta…",
+  "tools.locationReset": "Restablecer a predeterminada",
 } satisfies Partial<Messages>;
 
 export default es;

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -612,6 +612,15 @@ const fr = {
   "teamExample.product-discovery.2": "Recherchez ce que les concurrents livrent pour [problem] et recommandez la suite, avec hypothèses et risques explicites.",
   "teamExample.ai-builders.1": "Concevez et construisez [AI feature] sur une base data + prompts solide : schéma, retrieval, prompts et evals ; bouclez jusqu’à réussite sur un jeu réservé.",
   "teamExample.ai-builders.2": "Renforcez nos prompts pour [use case] : écrivez des cas de test, mesurez le taux de passage et itérez jusqu’à fiabilité.",
+  "tools.location": "Emplacement",
+  "tools.locationTitle": "Définir un emplacement d’installation personnalisé pour {tool}",
+  "tools.customLocation": "emplacement personnalisé",
+  "tools.installLocation": "Emplacement d’installation",
+  "tools.locationDefault": "Par défaut (~)",
+  "tools.locationDefaultTitle": "Par défaut (répertoire personnel)",
+  "tools.locationHint": "Pointez {tool} vers un répertoire de base personnalisé — par exemple un dossier personnel WSL ({wsl}) depuis l’application Windows. La détection et les installations globales utilisateur le suivent ; les installations de projet ne sont pas affectées.",
+  "tools.locationChoose": "Choisir un dossier…",
+  "tools.locationReset": "Réinitialiser par défaut",
 } satisfies Partial<Messages>;
 
 export default fr;

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -612,6 +612,15 @@ const ja = {
   "teamExample.product-discovery.2": "競合が [problem] に対して何を提供しているかを調査し、次に作るべきものを提案してください。前提とリスクも明示します。",
   "teamExample.ai-builders.1": "堅実なデータとプロンプト基盤の上に [AI feature] を設計・実装してください。スキーマ、検索、プロンプト、評価を整え、保留データセットで評価が通るまで反復します。",
   "teamExample.ai-builders.2": "[use case] 向けのプロンプトを強化してください。テストケースを書き、合格率を測定し、信頼できる状態になるまで反復します。",
+  "tools.location": "場所",
+  "tools.locationTitle": "{tool} のカスタムインストール先を設定",
+  "tools.customLocation": "カスタム場所",
+  "tools.installLocation": "インストール先",
+  "tools.locationDefault": "デフォルト (~)",
+  "tools.locationDefaultTitle": "デフォルト（ホームディレクトリ）",
+  "tools.locationHint": "{tool} をカスタムのベースディレクトリに向けます——例えば Windows アプリから WSL のホーム（{wsl}）へ。検出とユーザーグローバルのインストールがそこに従います。プロジェクトのインストールには影響しません。",
+  "tools.locationChoose": "フォルダーを選択…",
+  "tools.locationReset": "デフォルトに戻す",
 } satisfies Partial<Messages>;
 
 export default ja;

--- a/src/lib/i18n/locales/ko.ts
+++ b/src/lib/i18n/locales/ko.ts
@@ -612,6 +612,15 @@ const ko = {
   "teamExample.product-discovery.2": "경쟁사가 [problem]에 대해 무엇을 제공하는지 조사하고, 우리가 다음에 무엇을 만들어야 하는지 추천하세요. 가정과 위험도 함께 명시합니다.",
   "teamExample.ai-builders.1": "탄탄한 데이터와 프롬프트 기반 위에 [AI feature]를 설계하고 구축하세요. 스키마, 검색, 프롬프트, 평가를 갖추고 보류 데이터셋에서 평가가 통과할 때까지 반복합니다.",
   "teamExample.ai-builders.2": "[use case]용 프롬프트를 강화하세요. 테스트 케이스를 작성하고 통과율을 측정한 뒤, 신뢰할 수 있는 수준이 될 때까지 반복합니다.",
+  "tools.location": "위치",
+  "tools.locationTitle": "{tool}의 사용자 지정 설치 위치 설정",
+  "tools.customLocation": "사용자 지정 위치",
+  "tools.installLocation": "설치 위치",
+  "tools.locationDefault": "기본값 (~)",
+  "tools.locationDefaultTitle": "기본값(홈 디렉터리)",
+  "tools.locationHint": "{tool}을(를) 사용자 지정 기본 디렉터리로 지정합니다 — 예: Windows 앱에서 WSL 홈({wsl}). 감지와 사용자 전역 설치가 이를 따릅니다. 프로젝트 설치에는 영향을 주지 않습니다.",
+  "tools.locationChoose": "폴더 선택…",
+  "tools.locationReset": "기본값으로 재설정",
 } satisfies Partial<Messages>;
 
 export default ko;

--- a/src/lib/i18n/locales/pt-BR.ts
+++ b/src/lib/i18n/locales/pt-BR.ts
@@ -612,6 +612,15 @@ const ptBR = {
   "teamExample.product-discovery.2": "Pesquise o que concorrentes entregam para [problem] e recomende o que construir em seguida, com suposições e riscos destacados.",
   "teamExample.ai-builders.1": "Projete e construa [AI feature] sobre base sólida de dados e prompts: schema, retrieval, prompts e evals; itere até as evals passarem em um conjunto reservado.",
   "teamExample.ai-builders.2": "Reforce nossos prompts para [use case]: escreva casos de teste, meça a taxa de aprovação e itere até ficar confiável.",
+  "tools.location": "Local",
+  "tools.locationTitle": "Definir um local de instalação personalizado para {tool}",
+  "tools.customLocation": "local personalizado",
+  "tools.installLocation": "Local de instalação",
+  "tools.locationDefault": "Padrão (~)",
+  "tools.locationDefaultTitle": "Padrão (diretório inicial)",
+  "tools.locationHint": "Aponte {tool} para um diretório base personalizado — por exemplo, um diretório inicial do WSL ({wsl}) a partir do app do Windows. A detecção e as instalações globais do usuário seguem esse local; instalações de projeto não são afetadas.",
+  "tools.locationChoose": "Escolher pasta…",
+  "tools.locationReset": "Redefinir para o padrão",
 } satisfies Partial<Messages>;
 
 export default ptBR;

--- a/src/lib/i18n/locales/zh-CN.ts
+++ b/src/lib/i18n/locales/zh-CN.ts
@@ -612,6 +612,15 @@ const zhCN = {
   "teamExample.product-discovery.2": "研究竞品如何解决 [problem]，提出我们下一步该构建什么，并说明假设和风险。",
   "teamExample.ai-builders.1": "基于扎实的数据和提示词基础设计并构建 [AI feature]：schema、检索、提示词和评测都要到位，循环到留出集评测通过。",
   "teamExample.ai-builders.2": "加固 [use case] 的提示词：编写测试用例，衡量通过率，并迭代到稳定可靠。",
+  "tools.location": "位置",
+  "tools.locationTitle": "为 {tool} 设置自定义安装位置",
+  "tools.customLocation": "自定义位置",
+  "tools.installLocation": "安装位置",
+  "tools.locationDefault": "默认 (~)",
+  "tools.locationDefaultTitle": "默认（主目录）",
+  "tools.locationHint": "将 {tool} 指向自定义的基础目录——例如从 Windows 应用指向 WSL 主目录（{wsl}）。检测和用户全局安装都会使用该目录；项目安装不受影响。",
+  "tools.locationChoose": "选择文件夹…",
+  "tools.locationReset": "恢复默认",
 } satisfies Partial<Messages>;
 
 export default zhCN;

--- a/src/lib/i18n/locales/zh-TW.ts
+++ b/src/lib/i18n/locales/zh-TW.ts
@@ -612,6 +612,15 @@ const zhTW = {
   "teamExample.product-discovery.2": "研究競品如何解決 [problem]，提出我們下一步該建構什麼，並說明假設和風險。",
   "teamExample.ai-builders.1": "基於紮實的資料和提示詞基礎設計並建構 [AI feature]：schema、檢索、提示詞和評測都要到位，循環到保留集評測通過。",
   "teamExample.ai-builders.2": "加固 [use case] 的提示詞：撰寫測試案例，衡量通過率，並迭代到穩定可靠。",
+  "tools.location": "位置",
+  "tools.locationTitle": "為 {tool} 設定自訂安裝位置",
+  "tools.customLocation": "自訂位置",
+  "tools.installLocation": "安裝位置",
+  "tools.locationDefault": "預設 (~)",
+  "tools.locationDefaultTitle": "預設（主目錄）",
+  "tools.locationHint": "將 {tool} 指向自訂的基礎目錄——例如從 Windows 應用程式指向 WSL 主目錄（{wsl}）。偵測與使用者全域安裝都會使用該目錄；專案安裝不受影響。",
+  "tools.locationChoose": "選擇資料夾…",
+  "tools.locationReset": "還原預設值",
 } satisfies Partial<Messages>;
 
 export default zhTW;


### PR DESCRIPTION
Follow-up to #39. That PR added the per-tool **install location** control (Tools pane) and its 9 `tools.location*` keys to `en.ts` — but the other locales fell back to English for them. This translates all nine into the eight non-English languages so every language is back at full parity (620/620 keys).

- Languages: `zh-CN`, `zh-TW`, `ja`, `ko`, `es`, `fr`, `de`, `pt-BR`
- `{tool}` / `{wsl}` placeholders preserved
- `npm run check` clean; `npm run build` clean

**Russian** is intentionally not included — deferred to @DrMaks22's resubmit (his complete `ru.ts` against the current key set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)