### PR TITLE
fix(deploy): make tool cells read as install actions, not status

### DIFF
--- a/src/lib/components/DeployBrowser.svelte
+++ b/src/lib/components/DeployBrowser.svelte
@@ -340,11 +340,12 @@
                   {:else if cov.all}<span class="dot full"></span>
                   {:else if cov.some}<span class="dot half"></span>
                   {:else}<span class="dot"></span>{/if}
-                  <span class="t-count">{#if cov.all}{i18n.t("deploy.cellAll", { count: setTotal })}{:else if cov.some}{i18n.t("deploy.cellPartial", { count: cov.count, total: setTotal })}{:else}{i18n.t("deploy.cellNone")}{/if}</span>
+                  <span class="t-count" class:cta={!cov.all && !cov.some}>{#if cov.all}{i18n.t("deploy.cellAll", { count: setTotal })}{:else if cov.some}{i18n.t("deploy.cellPartial", { count: cov.count, total: setTotal })}{:else}{i18n.t("deploy.cellInstall")}{/if}</span>
                 </button>
               {/each}
             </div>
           </div>
+          <p class="grid-hint">{i18n.t("deploy.pickTool")}</p>
         {/if}
 
         <p class="d-section">{i18n.count(setTotal, "common.agent.one", "common.agent.many")}{#if agentGroups.length > 1} · {i18n.count(agentGroups.length, "common.division.one", "common.division.many")}{/if}</p>
@@ -461,6 +462,10 @@
   .cell.toggle:hover:not(:disabled) { background: var(--color-surface-sunken); }
   .cell.toggle:disabled { cursor: default; }
   .t-count { font-size: 10px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; line-height: 1; }
+  .t-count.cta { color: var(--color-brand); font-weight: var(--fw-semibold); }
+  .cell.toggle:disabled .t-count.cta { color: var(--color-text-muted); }
+
+  .grid-hint { margin: var(--space-2) 0 0; font-size: var(--text-caption); color: var(--color-text-muted); line-height: 1.4; }
 
   .dot { width: 16px; height: 16px; border-radius: 999px; border: 1.5px solid var(--color-border-strong, var(--color-text-muted)); box-sizing: border-box; }
   .dot.full { background: var(--color-brand); border-color: var(--color-brand); }

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -353,6 +353,8 @@ const en = {
   "deploy.cellAll": "all {count}",
   "deploy.cellPartial": "{count}/{total}",
   "deploy.cellNone": "none",
+  "deploy.cellInstall": "Install",
+  "deploy.pickTool": "Pick a tool above to deploy these agents into it — agents install as tool-specific files, so there's no install without a target.",
   "deploy.pickLeft": "Pick something on the left to deploy.",
   "activity.action.install": "Installed",
   "activity.action.uninstall": "Removed",


### PR DESCRIPTION
Follow-up to a UX snag: the "Deploy into <project>" modal looked like it was missing an Install button. It wasn't — **the tool cells are the install buttons** (click a tool column → deploys the selected agents into that tool for the project). But an empty cell rendered a hollow dot labeled **"none"**, which reads as read-only status rather than a call to action.

Why there's no single primary button: an agent only becomes a file when it's **rendered for a specific tool** (Claude Code → `.claude/agents/*.md`, Cursor → `.cursor/rules/*.mdc`, …). A tool-agnostic "install" has no destination or format — so the per-tool cell *is* the honest commit point.

## Changes
- Empty cell now reads **"Install"** (brand-colored CTA) instead of "none".
- One-line hint under the grid: *"Pick a tool above to deploy these agents into it…"*
- Filled (`all 5`) / partial (`3/5`) states + click-to-remove unchanged.
- English-only strings; other locales fall back until translated (per the content-scan rule in CONTRIBUTING).

`npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdX6PvnCfRgYD11yVpXVor