### PR TITLE
release: v0.3.0 — version bump + release notes

### DIFF
--- a/docs/release-notes/0.3.0.md
+++ b/docs/release-notes/0.3.0.md
@@ -1,0 +1,55 @@
+## Agency Agents v0.3.0 — 2026-07-05
+
+The first release with **Runbooks** — and the biggest feature drop since the app went public. Runbooks turn the catalog's NEXUS scenario playbooks into one-click orchestrated deployments: pick a scenario like "Startup MVP," and the app assembles the proven agent team and installs it into your project. This build also folds in everything since v0.2.1 — a 10-language UI, a new tool, smarter install tracking, and a foundational catalog fix.
+
+### Downloads
+
+- **macOS** (Apple Silicon & Intel) — signed + notarized `.dmg`, launches without warnings. macOS 13+.
+- **Linux** (x86_64) — `.deb` (Debian/Ubuntu), `.rpm` (Fedora/RHEL/openSUSE), or the portable `.AppImage`.
+- **Windows** (x64 & ARM64) — `.exe` installer. Not code-signed yet, so SmartScreen warns on first launch → **More info → Run anyway** (see Known Notes).
+
+Or visit [agencyagents.app](https://agencyagents.app). v0.2.x users: accept the in-app update prompt.
+
+### Highlights
+
+**Runbooks — deploy a scenario team in one step (new pillar).**
+
+- A new **Runbooks** section in the sidebar surfaces the NEXUS scenario playbooks — *Startup MVP*, *Enterprise Feature*, *Incident Response*, *Marketing Campaign* — each a proven roster grouped into Core / Growth / Support teams.
+- **Deploy team…** installs the whole roster into a project through the standard destinations × tools picker — no assembling agents one at a time.
+- **Copy activation prompt** puts a ready NEXUS activation prompt on your clipboard.
+- Rosters resolve by stable agent id, so what you deploy always matches the catalog.
+- Runbooks live in the catalog's `strategy/` playbooks, so they appear once your catalog is synced from GitHub (see Known Notes).
+
+**Your catalog, current.**
+
+- The dashboard gains an **Update from GitHub** control when you manage a catalog clone — pull the latest agents and divisions without leaving the app.
+- Divisions now come straight from the catalog's `divisions.json`, so a newly added division (**Healthcare**, **GIS**) shows up the moment you sync — and a directory that isn't a real division (like the `strategy/` playbooks) is never shown as an empty one again.
+
+**Speaks your language.**
+
+- The entire UI is now translatable, shipping with **9 languages** plus a community **Russian** translation — English, Simplified & Traditional Chinese, Japanese, Korean, Spanish, French, German, Brazilian Portuguese, and Russian. Change it in Settings → Appearance. (Agent catalog content stays as authored upstream.)
+
+**More tools, more control.**
+
+- **Antigravity** joins the supported tools — Agency agents install as native Antigravity skills.
+- **Per-tool install locations**: point a tool at a custom base directory (e.g. a WSL home from the Windows app) in the Tools view; detection and user-global installs follow it.
+
+**Smarter install tracking.**
+
+- Reconcile now **adopts byte-perfect installs**: an agent already on disk that exactly matches the catalog (e.g. from the CLI installer) is recognized as managed, not left as a stranger.
+- It also scans your **registered project folders**, so re-adding a project resurfaces the agents already installed in it.
+
+**Projects & deploy polish.**
+
+- **Delete project** works as expected, with a clear choice: remove it from the app (keep the files) or remove and uninstall the agents it installed — never your own project files.
+- In the "Deploy into project" picker, empty tool cells now read **Install** with a hint, instead of a mystifying "none."
+
+**Linux fix.**
+
+- Fixed the `EGL_BAD_PARAMETER` crash that kept the AppImage from launching on many Linux GPU/driver stacks (Arch, NVIDIA/Wayland, newer Mesa) — issue #641.
+
+### Known Notes
+
+- **Fresh installs start from a bundled catalog snapshot.** Until you sync (**Update from GitHub**, or Settings → Catalog → "Set one up for me"), the **GIS** and **Healthcare** divisions appear empty and **Runbooks shows a "sync to unlock" prompt** — the bundled snapshot predates those agents and doesn't carry the `strategy/` playbooks. A refreshed bundled catalog is coming in a follow-up.
+- **Windows builds aren't code-signed yet.** SmartScreen warns on first launch; click **More info → Run anyway**. macOS and the update path are fully signed + notarized.
+- **v0.2.x users** are offered this build automatically through the in-app updater.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agency-agents-app",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Agency Agents — a native macOS app store for AI agents. Browse, install, and track 251+ specialized agents across every AI coding tool.",
   "type": "module",
   "author": "Michael Sitarzewski",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agency-agents-app"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agency-agents-app"
-version = "0.2.1"
+version = "0.3.0"
 description = "Agency Agents — a native macOS app store for AI agents."
 authors = ["Michael Sitarzewski"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Agency Agents",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "identifier": "com.zerologic.agency-agents-app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release prep for **v0.3.0** — version bump (0.2.1 → 0.3.0 across package.json / tauri.conf.json / Cargo.toml / Cargo.lock) + `docs/release-notes/0.3.0.md`.

**Headline:** Runbooks — the NEXUS scenario launcher. Plus the full rollup since v0.2.1 (10-language i18n incl. Russian, Antigravity, per-tool install paths, delete-project, reconcile discover+adopt, divisions-from-`divisions.json`, Update-from-GitHub, Linux EGL fix, deploy-cell copy).

Release notes call out the known limitation: fresh installs start from the bundled snapshot, so GIS/Healthcare divisions + Runbooks unlock once the catalog is synced (**Update from GitHub**). Baseline re-vendor (#51) is queued as a v0.3.1 fast-follow.

After this merges: tag `v0.3.0` → CI (Linux/Windows) + `release.sh` (macOS, signed+notarized) → GitHub release → publish `updater.json` → bump brew cask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdX6PvnCfRgYD11yVpXVor