### PR TITLE
fix(linux): un-bundle libwayland from AppImage to stop EGL crash (#57)

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -74,6 +74,39 @@ jobs:
       - name: Build Tauri app
         run: npm run tauri build -- --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
+      # Un-bundle the Wayland client libs from the AppImage (#57).
+      #
+      # linuxdeploy bundles libwebkit2gtk's transitive libwayland-* into the
+      # AppImage. Those are built against an older Mesa than the *host* is
+      # running, so when libEGL_mesa initializes the Wayland platform it hits a
+      # protocol/ABI mismatch and aborts with "Could not create default EGL
+      # display: EGL_BAD_PARAMETER" — the webview never appears. The failure is
+      # in EGL display init, BEFORE WebKit reads WEBKIT_DISABLE_DMABUF_RENDERER
+      # (our lib.rs runtime lever, #641/#36), which is why no env var can fix it.
+      #
+      # libwayland (like libGL/libEGL/libgbm/libdrm, which linuxdeploy already
+      # excludes) MUST come from the running system to match the loaded EGL
+      # stack. So strip the four bundled copies and repack — the host's copies
+      # then load. Only the AppImage bundles libs; .deb/.rpm link system libwayland.
+      - name: "Un-bundle host Wayland libs from AppImage (fixes EGL crash, #57)"
+        run: |
+          set -euo pipefail
+          cd src-tauri/target/release/bundle/appimage
+          APP="$(ls *.AppImage)"
+          echo "Repacking $APP without bundled libwayland-*"
+          ./"$APP" --appimage-extract >/dev/null
+          find squashfs-root -type f \( \
+              -name 'libwayland-client.so.*' -o \
+              -name 'libwayland-cursor.so.*' -o \
+              -name 'libwayland-egl.so.*' -o \
+              -name 'libwayland-server.so.*' \) -print -delete
+          wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool
+          chmod +x appimagetool
+          ARCH=x86_64 ./appimagetool --appimage-extract-and-run squashfs-root "$APP.new"
+          mv -f "$APP.new" "$APP"
+          rm -rf squashfs-root appimagetool
+          echo "Done — $APP now defers libwayland to the host."
+
       - name: Upload .deb
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Fixes #57 — the AppImage aborts on launch with `Could not create default EGL display: EGL_BAD_PARAMETER` on Arch Linux / Hyprland (Wayland) / Intel UHD 620 / recent Mesa. The reporter tried every known WebKit env var (`WEBKIT_DISABLE_DMABUF_RENDERER`, `WEBKIT_DISABLE_COMPOSITING_MODE`, `LIBGL_ALWAYS_SOFTWARE`, `GDK_BACKEND=x11`, `LD_PRELOAD`, …) — none helped.

## Root cause (distinct from #641/#36)

`linuxdeploy` bundles libwebkit2gtk's transitive `libwayland-client/cursor/egl/server` into the AppImage. Those are built against an **older Mesa** than the host is running, so when `libEGL_mesa` initializes the Wayland platform it hits a protocol/ABI mismatch and aborts **in EGL display init** — *before* WebKit reads `WEBKIT_DISABLE_DMABUF_RENDERER` (our `lib.rs` runtime lever from #36/#641). That's precisely why no env var has any effect here. This is a **deeper, different case** than #641, which our DMABUF guard does still cover for the NVIDIA cohort.

## Fix

`libwayland` — like `libGL`/`libEGL`/`libgbm`/`libdrm`, which linuxdeploy already excludes — **must come from the running system** to match the loaded EGL stack. So after the Tauri build, before upload, the workflow extracts the AppImage, strips the four bundled `libwayland-*` copies, and repacks. The host's Mesa-matched copies then load. `libwayland` has had a frozen soname for a decade, so deferring to the host is universally safe.

Only the AppImage bundles libraries — `.deb`/`.rpm` link the system `libwayland` and are unaffected.

## Notes

- Repack uses `appimagetool --appimage-extract-and-run` (no FUSE needed on the runner) and writes to a temp name then `mv -f`, so there's no "output exists" refusal.
- Removal is path-tolerant (`find … -name 'libwayland-*.so.*' -delete`) and a no-op if the libs aren't present.
- The existing `WEBKIT_DISABLE_DMABUF_RENDERER=1` runtime lever is kept, unchanged — complementary, not conflicting.

## Verification

Can't be exercised from macOS. Proof is a green **Linux Build** run (dispatched against this branch) whose new step logs the four removed libs and still produces a valid AppImage — then the reporter confirming on their Arch/Hyprland box.

Sources: [espressif/idf-im-ui#755](https://github.com/espressif/idf-im-ui/issues/755) · [Yaak Linux/Wayland fixes](https://yaak.app/feedback/posts/fix-blank-screen-crash-on-linux-due-to-wayland-nvidia-etc) · [Tauri Linux Graphics docs](https://v2.tauri.app/develop/debug/linux-graphics/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)