### PR TITLE
fix(windows): embed the WebView2 bootstrapper in the installer

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -58,6 +58,9 @@
         "appPosition": { "x": 140, "y": 190 },
         "applicationFolderPosition": { "x": 400, "y": 190 }
       }
+    },
+    "windows": {
+      "webviewInstallMode": { "type": "embedBootstrapper" }
     }
   }
 }


### PR DESCRIPTION
## Summary

`bundle.windows` was absent, so Tauri defaulted the WebView2 install to **`downloadBootstrapper`** — the installer downloads even the *bootstrapper* over the network. If that download is blocked (offline/proxy/firewall) and the machine lacks WebView2, the app installs but has **no runtime → launches with no window and no error** — the shape of #65.

`embedBootstrapper` ships the bootstrapper inside the installer (~1.5 MB), removing that failure mode.

## Honesty on scope
Windows 11 already bundles the WebView2 runtime, so this is **unlikely to be the actual cause of #65** (those reporters have WebView2). It mainly hardens Win10 / LTSC / stripped / offline installs. Belt-and-braces while we chase the real #65 cause (looks x64/GPU-specific — [I couldn't reproduce it on a Windows 11 ARM64 VM](https://github.com/msitarzewski/agency-agents-app/issues/65), where v0.3.0 launches and renders fine).

## Verification
`tauri.conf.json` parses; only affects the Windows installer (no macOS impact). Will confirm on the next Windows CI build.

Refs #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)