### PR TITLE
fix(build): make npm run tauri pass the correct TAURI_CONFIG to the CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "tauri": "tauri"
+    "tauri": "node tools/tauri-run.mjs"
   },
   "license": "MIT",
   "dependencies": {

--- a/tools/tauri-run.mjs
+++ b/tools/tauri-run.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Wrapper for `npm run tauri` (dev/build/bundle).
+//
+// Why this exists: tauri-cli 2.11.2 does not export TAURI_CONFIG to the
+// cargo child process it spawns for `tauri dev`/`tauri build`, contrary to
+// the assumption baked into `.cargo/config.toml`'s `[env] TAURI_CONFIG`
+// fallback (confirmed by tracing the actual env cargo receives). That
+// fallback pins `macOSPrivateApi: false` so plain `cargo build`/`cargo test`
+// pass tauri-build's feature-allowlist check against the intentionally
+// featureless base `tauri` dependency (see tools/phase-c/validate-config.mjs).
+//
+// Left alone, that same false value leaks into real `tauri dev`/`tauri
+// build` runs too — and TAURI_CONFIG is also read by `generate_context!()`
+// to build the config embedded in the compiled binary, so this isn't just a
+// build-script lint: a real release build would silently ship with the
+// macOS private-API window styling disabled, no error.
+//
+// Fix: explicitly set TAURI_CONFIG for CLI-driven runs only, computed from
+// the actual platform config file rather than hardcoded, so it stays
+// correct if that value ever changes. This env var wins over
+// `.cargo/config.toml`'s fallback (cargo's `[env]` never overrides a value
+// already present in the process environment).
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const repo = path.resolve(import.meta.dirname, "..");
+
+let macOSPrivateApi = false;
+if (process.platform === "darwin") {
+  const macConf = JSON.parse(
+    readFileSync(path.join(repo, "src-tauri/tauri.macos.conf.json"), "utf8"),
+  );
+  macOSPrivateApi = macConf.app?.macOSPrivateApi === true;
+}
+
+const result = spawnSync("tauri", process.argv.slice(2), {
+  stdio: "inherit",
+  cwd: repo,
+  env: {
+    ...process.env,
+    TAURI_CONFIG: JSON.stringify({ app: { macOSPrivateApi } }),
+  },
+});
+
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

Fresh checkouts fail `tauri dev` and `tauri build` on macOS with tauri-build's feature-allowlist error:

```
The `tauri` dependency features on the `Cargo.toml` file does not match the allowlist defined under `tauri.conf.json`.
```

Traced the root cause by wrapping `cargo` in a shim that logs every env var it receives from tauri-cli 2.11.2: `TAURI_CONFIG` is never set for the CLI's build step, contrary to the assumption in `.cargo/config.toml`'s comment ("the Tauri CLI sets its own fully-merged TAURI_CONFIG, which therefore wins"). That file's `TAURI_CONFIG=false` fallback — needed so plain `cargo build`/`cargo test` match the intentionally featureless base `tauri` dependency (see `tools/phase-c/validate-config.mjs`) — silently leaks into real CLI runs instead.

This is worse than a build-script lint: the same `TAURI_CONFIG` env var is also read by `generate_context!()` to build the config embedded in the compiled binary, so a real `tauri build` release would silently ship with the macOS private-API window styling disabled — no error, just wrong runtime behavior.

## Fix

`tools/tauri-run.mjs` computes the correct `macOSPrivateApi` value from `tauri.macos.conf.json` (not hardcoded, stays correct if that value changes) and sets `TAURI_CONFIG` explicitly before spawning the real CLI, winning over the `.cargo/config.toml` fallback (cargo's `[env]` never overrides an already-set var). Uses Node's `spawnSync` rather than shell env-var syntax so it works identically on the Windows/Ubuntu Parallels CI legs, which invoke the same `npm run tauri -- build --no-bundle` entrypoint.

`.cargo/config.toml` is untouched: its `false` fallback still correctly serves `cargo test`/`cargo build` and phase-c's release-build step, which don't exercise `generate_context!()`'s runtime path.

## Test plan

Verified cold (fresh clone, `rm -rf target`) on macOS:
- [x] `npm run tauri dev` — starts and builds cleanly
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 272 passed
- [x] `npm run build`
- [x] `npm run build:phase-c` — 6/6 passed
- [x] `PHASE_C_STRICT_TAURI=1 npm run build:phase-c` — 7/7 passed, including the real `tauri build --no-bundle` path