### PR TITLE
feat(i18n): RTL layout support (Phase 1) — dir switch + title-bar mirror

### DIFF
--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -278,7 +278,7 @@
   .close {
     position: absolute;
     top: var(--space-3);
-    right: var(--space-3);
+    inset-inline-end: var(--space-3); /* right in LTR, left in RTL */
     color: var(--color-text-muted);
     padding: 4px;
     border-radius: var(--radius-sm);

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -19,6 +19,13 @@ export function isLocale(value: string): value is Locale {
   return (LOCALES as readonly string[]).includes(value);
 }
 
+/** Locales that render right-to-left. Drives `document.documentElement.dir`. */
+export const RTL_LOCALES = new Set<Locale>(["fa"]);
+
+export function isRTL(locale: Locale): boolean {
+  return RTL_LOCALES.has(locale);
+}
+
 export const localeLabels: Record<Locale, string> = {
   en: "English",
   "zh-CN": "简体中文",

--- a/src/lib/stores/i18n.svelte.ts
+++ b/src/lib/stores/i18n.svelte.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LOCALE, LOCALES, isLocale, messages, type Locale, type MessageKey } from "$lib/i18n/messages";
+import { DEFAULT_LOCALE, LOCALES, isLocale, isRTL, messages, type Locale, type MessageKey } from "$lib/i18n/messages";
 
 const STORAGE_KEY = "agency-agents:locale";
 
@@ -28,7 +28,13 @@ function detectLocale(): Locale {
 }
 
 function applyLocale(locale: Locale) {
-  if (typeof document !== "undefined") document.documentElement.lang = locale;
+  if (typeof document !== "undefined") {
+    document.documentElement.lang = locale;
+    // Phase 1 RTL: flip the document direction for right-to-left locales.
+    // Flexbox/inline flow mirrors off this for free; physical-property
+    // polish (margins, positioning, icons) is a follow-up.
+    document.documentElement.dir = isRTL(locale) ? "rtl" : "ltr";
+  }
 }
 
 function format(template: string, vars?: Record<string, string | number>): string {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -375,6 +375,31 @@
        absorbed by the layout — no empty space when nothing to show. */
     gap: 8px;
   }
+  /* ── RTL title bar ─────────────────────────────────────────────────
+     The title bar is absolutely positioned by physical offsets (it can't
+     mirror off flex like the rest of the app), so swap the horizontal
+     anchors by hand for right-to-left. The macOS traffic lights never
+     mirror — they stay top-left — so the icon cluster, which lands on the
+     left in RTL, gets clearance past them on macOS. */
+  :global(html[dir="rtl"]) .titlebar-btn:not(.nav) {
+    left: auto;
+    right: var(--titlebar-toggle-left);
+  }
+  :global(html[dir="rtl"]) .titlebar-nav {
+    left: auto;
+    right: var(--titlebar-title-left);
+  }
+  :global(html[dir="rtl"]) .titlebar-title {
+    left: auto;
+    right: calc(var(--titlebar-title-left) + 62px);
+  }
+  :global(html[dir="rtl"]) .titlebar-right {
+    right: auto;
+    left: var(--space-4);
+  }
+  :global(html[dir="rtl"]) .app.macos .titlebar-right {
+    left: 84px; /* clear the traffic lights (they never mirror) */
+  }
   .main {
     flex: 1;
     display: flex;


### PR DESCRIPTION
## What
Right-to-left layout support, driven off the active locale. Persian (`fa`) today; Arabic/Hebrew ready when added to `RTL_LOCALES`.

The core is one line — `document.documentElement.dir = isRTL(locale) ? "rtl" : "ltr"` — and because the UI is flexbox-heavy, **most of the app mirrors for free** (sidebar, cards, rows, modals, the Settings panel). This PR handles the two spots that *can't* mirror off flex.

## Changes
- **`messages.ts`** — `RTL_LOCALES` set + `isRTL(locale)` helper.
- **`i18n.svelte.ts`** — `applyLocale()` sets `dir` next to `lang`, so both first paint and picker switches flip direction.
- **`+page.svelte`** — the title bar is absolutely positioned by physical `left:` offsets (tied to sidebar width), so it's swapped to `right:` in RTL. The macOS **traffic lights never mirror**, so the icon cluster that lands on the left gets clearance past them on macOS.
- **`Settings.svelte`** — the bespoke close-X used physical `right:` → `inset-inline-end` (top-left in RTL).

## Verified
Live in Persian on macOS: sidebar → right, title bar mirrored with traffic-light clearance, Settings modal + close-X mirrored. `npm run check` clean.

## Phase 2 (separate follow-up)
Logical-property sweep for the remaining overlay positions (~13: Toast, CommandPalette, InstallModal, DiffModal, …), `text-align: left`→`start` (~38), the division-row internals, and directional-icon (chevron/arrow) mirroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)