### PR TITLE
fix(i18n): add missing Healthcare division label

### DIFF
--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -411,6 +411,7 @@ const en = {
   "category.finance": "Finance",
   "category.game-development": "Game Development",
   "category.gis": "GIS",
+  "category.healthcare": "Healthcare",
   "category.marketing": "Marketing",
   "category.paid-media": "Paid Media",
   "category.product": "Product",

--- a/src/lib/i18n/locales/fa.ts
+++ b/src/lib/i18n/locales/fa.ts
@@ -413,6 +413,7 @@ const fa = {
   "category.finance": "مالی",
   "category.game-development": "توسعه بازی",
   "category.gis": "GIS",
+  "category.healthcare": "سلامت",
   "category.marketing": "بازاریابی",
   "category.paid-media": "رسانه پولی",
   "category.product": "محصول",


### PR DESCRIPTION
When the catalog replaced the `strategy` division with `healthcare` (#52), the app's `category.*` labels weren't updated — they still carry a stale `category.strategy` and have **no `category.healthcare`**. So the Healthcare division falls back to the catalog's raw English label in every locale.

It's most visible in Persian (this session's RTL work), where **every division localized except Healthcare**:

- **`en.ts`** — add `"category.healthcare": "Healthcare"` (source of truth).
- **`fa.ts`** — add `"category.healthcare": "سلامت"`.

Other locales fall back to the English label gracefully via `i18n.optional()`. The dead `category.strategy` key is left alone (removing it touches all 10 locales — out of scope). GIS stays `"GIS"` in both (acronym, intentional). `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)