### PR TITLE
docs(memory-bank): catch up to 2026-08-10 (post-v0.3.0 arc + RTL Phase 1)

### DIFF
--- a/memory-bank/NEXT-SESSION.md
+++ b/memory-bank/NEXT-SESSION.md
@@ -3,7 +3,54 @@
 Read this first after a compaction. Then `activeContext.md`, `agentLog.md` (append-only history),
 `phases/phase-roadmap.md`, `contracts.md`, `systemPatterns.md`, `decisions.md`.
 
-## ⏩ CURRENT (2026-06-23) — read `activeContext.md` for the live picture
+## ⏩ CURRENT (2026-08-10) — post-v0.3.0 steady state; RTL Phase 1 in flight
+`main` @ `04c10be` (Persian #73 merged). **v0.3.0 shipped ~07-05** (Runbooks headline). Since then: a long
+steady-state of contributor merges + polish + i18n; **no new release cut yet**.
+
+**Merged this arc (all branch→PR):** #56 i18n copy · #58 Linux AppImage EGL crash (un-bundle stale libwayland)
+· #59 Russian Runbooks · **#68 agent-updates modal** ("N updates available" agents×tools dot-grid) · **#64 ZCode
+tool** (Z.ai GLM; `zcode-md` == `qwen-md`) + **#70 ZCode brand icon** (lobehub zhipu mark) · #63 project-only
+install guidance (**closed #40**) · **#74 Antigravity uninstall fix** (`remove_dir` the orphaned skill-md
+`<slug>/` dir — **closed #60**) · **#73 Persian (fa-IR)** (montajebii; **closed #72**).
+
+**OPEN PRs (8, all MERGEABLE):** **#81 RTL Phase 1** (mine) · **#82 Healthcare division label** (mine) · #85
+Windows console flash · #80 winget README · #77 `npm run tauri` TAURI_CONFIG fix (kills the macos-private-api
+footgun properly) · #69 WebView2 embedBootstrapper · #67 clone-on-first-run (removes bundled baseline — big
+surface) · #62 Runbooks doc-render/staged. → **#67/#69 want Linux+Windows CI dispatched before merge** (app CI =
+tags/dispatch only).
+
+**RTL = this session's focus. Phase 1 = PR #81, verified live in Persian on macOS.** The switch is ONE line —
+`document.documentElement.dir = isRTL(locale) ? "rtl" : "ltr"` in `applyLocale` (i18n.svelte.ts) — and the
+flexbox-heavy UI mirrors ~everything for free. The two spots that CAN'T: the **titlebar** (absolutely positioned
+by physical `left:` offsets → swapped to `right:` in RTL in `+page.svelte`, with a macOS **traffic-light
+clearance** since the OS lights never mirror) and **Settings.svelte**'s bespoke close-X (`right:` →
+`inset-inline-end`). `RTL_LOCALES = ["fa"]` in messages.ts. **Phase 2 (NOT started, ~½ day, captured in #81
+body):** logical-property sweep of ~13 overlay positions (Toast/CommandPalette/InstallModal/DiffModal/…),
+`text-align: left`→`start` (~38), the division-row internals, and chevron/arrow directional-icon mirroring.
+**KEY DESIGN FACT:** agent names/descriptions are **catalog content (English, authored upstream) — NOT translated
+by design** (`en.ts:49` documents it: chrome is localized, "persona content stays as authored upstream"). Only
+app chrome + division `category.*` labels are i18n. So English agent names in a Persian UI = correct, not a bug.
+#82 fixed a stale-catalog i18n gap (app kept dead `category.strategy`, lacked `category.healthcare`).
+
+**OPEN ISSUES:** #79 "58 but only 57 identified" (screenshot-only, untriaged) · #76 catalog-aware "Find the right
+agent" recommender (my tracking issue crediting @Rawlus7's catalog #634 draft; referral posted, quiet) · #71
+OpenClaw + #66 Antigravity Windows detection ("installed-but-not-detected" pair, likely shared root cause; not
+started) · #65 Windows launch (waits on reporter) · #27 skills · #26 Hermes. #75 closed as spam.
+
+**DEV GOTCHAS (hard-won this session):** (1) `tauri dev` on macOS re-injects `macos-private-api` into base
+`Cargo.toml` — run with `--config '{"app":{"macOSPrivateApi":true}}'`, `git checkout Cargo.toml` after (PR #77
+fixes it). (2) **Vite does NOT watch `src-tauri/data/tools.json`** (outside `src/`) — after a change touching it,
+`⌘R` won't help; **restart the dev server**. Dev-only (prod bundles fresh). (3) A new catalog integration NEVER
+auto-appears — Tools list is compiled in (`registry.rs include_str!` + `IMPLEMENTED_FORMATS`), so it needs a
+**paired app PR** (def + renderer + format gate + icon). (4) Forcing locale via `init()` doesn't take on first
+paint (SSR→English, hydration doesn't re-flip) — use the picker or a saved localStorage locale.
+
+**Icon WIP:** a re-authored Liquid Glass `.icon` (neon brain render) was **reverted to `git stash`** — the render
+baked in its own frame/gloss/shadow, wrong shape for the OS-applied Liquid Glass pipeline. Recoverable if wanted.
+
+---
+
+## ⏩ (history) CURRENT (2026-06-23) — read `activeContext.md` for the live picture
 **v0.2.0 SHIPPED** (`main` @ `16182e5`, PRs #21 + #22) — first feature release since v0.1.0, rolling up the
 v0.1.1 IA re-org (divisions landing, Teams, Projects pillar, the single InstallModal grid + DeployBrowser) and
 v0.1.2 tool-registry/Osaurus/Playbook arc, **plus LIVE auto-update**. 9 release assets across macOS (aarch64+x64,

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,5 +1,15 @@
 # Active Context — Agency Agents
 
+**State (2026-08-10)**: **post-v0.3.0 steady state** — `main` @ `04c10be`. v0.3.0 shipped ~07-05 (Runbooks); since
+then contributor merges + polish + i18n, no new release. **Live focus: RTL localization** — Phase 1 is PR #81
+(dir switch + titlebar mirror + Settings close), verified live in Persian; Phase 2 (logical-property sweep, ~½ day)
+not started. 8 open PRs, all mergeable (#81 RTL, #82 healthcare label, #85, #80, #77, #69, #67, #62). **Read
+`NEXT-SESSION.md` (2026-08-10 block) for the full live picture** — it supersedes everything below this line.
+
+---
+
+## History — v0.2.0 ship state (2026-06-23)
+
 **State**: 🚀 **v0.2.0 SHIPPED (2026-06-23)** — `main` @ `16182e5`. First feature release since the v0.1.0
 launch (the internally-tracked "0.1.1"/"0.1.2" milestones were never cut separately — they ship here), and
 **auto-update is now LIVE** at [`agencyagents.app/updater.json`](https://agencyagents.app/updater.json) for

--- a/memory-bank/tasks/2026-08/README.md
+++ b/memory-bank/tasks/2026-08/README.md
@@ -1,0 +1,53 @@
+# Tasks — 2026-08 (catch-up: covers the 07→08 arc)
+
+The memory-bank went quiet after the v0.2.0 ship (2026-06-23); the working log through July lived in the
+per-session resume notes. This README catches the bank up on the July→August arc. `main` @ `04c10be`.
+See `NEXT-SESSION.md` (2026-08-10 block) for the authoritative live picture.
+
+## Shipped / merged (branch → PR → merge)
+
+- **v0.3.0 release (~07-05)** — Runbooks headline (strategy/ runbooks as their own nav pillar, ⌘5; Activity → ⌘6).
+- **#56** i18n copy fixes · **#58** Linux AppImage EGL crash — root cause was a stale bundled `libwayland-*`
+  vs host Mesa; fix un-bundles them in `linux-build.yml` (reporter-confirmed on Arch/Hyprland; **closed #57**).
+- **#59** Russian Runbooks i18n.
+- **#68** agent-updates modal — "N updates available" agents×tools **dot-grid** (matches InstallModal), per-agent
+  selection, drives `install.bulk("update", …)`.
+- **#64** ZCode tool support (Z.ai GLM harness; `zcode-md` renderer byte-identical to `qwen-md`) + **#70** ZCode
+  brand icon (lobehub `zhipu` mark, monochrome so it tints with the tool accent). Upstream-first: catalog #700
+  merged before app #64.
+- **#63** project-only install guidance (dead "—" → explanation; **closed #40**).
+- **#74** Antigravity uninstall fix — skill-md tools install each agent as a `<slug>/SKILL.md` **directory**;
+  uninstall only removed the leaf file, orphaning the dir, which the reconcile scan re-surfaced as an untracked
+  phantom. Fix: `remove_dir` the now-empty agent dir (empty-only, gated on `tool_is_dir_unit`). **Closed #60.**
+  CI green on Linux + Windows.
+- **#73** Persian (fa-IR) localization (contributor @montajebii; reviewed → change-requested → re-reviewed →
+  merged; **closed #72**).
+
+## In flight (open PRs)
+
+- **#81 RTL layout support (Phase 1)** — the session's focus. `document.documentElement.dir` off `isRTL(locale)`;
+  flexbox mirrors most of the UI for free. Hand-fixed the two non-flex spots: the **titlebar** (physical `left:`
+  → `right:` in RTL + macOS traffic-light clearance) and **Settings.svelte** close-X (`right:` →
+  `inset-inline-end`). Verified live in Persian on macOS. Phase 2 (logical-property sweep, ~½ day) not started.
+- **#82** add missing `category.healthcare` label (stale-catalog i18n gap; en + fa `سلامت`).
+- **#85** Windows console-flash · **#80** winget README · **#77** `npm run tauri` TAURI_CONFIG fix · **#69**
+  WebView2 embedBootstrapper · **#67** clone-on-first-run (removes bundled baseline) · **#62** Runbooks polish.
+  → #67/#69 need Linux+Windows CI dispatched before merge.
+
+## Key decisions / facts recorded this arc
+
+- **Localization is layered across two repos.** App chrome + division `category.*` labels are app i18n
+  (translatable). **Agent names/descriptions/personas are catalog content, authored upstream in English, and are
+  NOT translated by design** — documented in `en.ts:49`. English agent names inside a localized UI = correct.
+- **Catalog integrations never auto-appear in the app.** The Tools list is compiled in
+  (`registry.rs include_str!(tools.json)` + `IMPLEMENTED_FORMATS`), so every new tool needs a **paired app PR**
+  (definition + renderer + format gate + brand icon), even after the catalog ships it.
+- **clone-on-first-run pivot (#67)** — remove the bundled corpus snapshot (perpetually drifts) and clone the live
+  catalog from GitHub on first run instead. Tradeoff: first run needs network.
+
+## Dev gotchas (see NEXT-SESSION.md for the full list)
+
+- `tauri dev` on macOS re-injects `macos-private-api` into base `Cargo.toml`; run with
+  `--config '{"app":{"macOSPrivateApi":true}}'` and revert Cargo.toml after (PR #77 fixes it).
+- Vite does not watch `src-tauri/data/tools.json` (outside `src/`) — restart the dev server after it changes; a
+  webview reload won't pick it up. Dev-only.


### PR DESCRIPTION
Brings the memory-bank current — it had gone quiet after the v0.2.0 ship (2026-06-23), so all of July's work lived only in per-session resume notes.

- **NEXT-SESSION.md** — new `⏩ CURRENT (2026-08-10)` block: the 07→08 merge arc, the 8 open PRs, RTL Phase 1 state + Phase 2 punch-list, the layered-localization design fact (agent content is catalog/English by design), and the hard-won dev gotchas. Old block retained as history.
- **activeContext.md** — current state line; old v0.2.0 state marked history.
- **tasks/2026-08/README.md** — catch-up monthly summary.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)